### PR TITLE
Circle Deploys k8s to staging on merge to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ jspm_packages
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
+
+
+# mocha-junit-reporter
+test-results.xml

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 # Retraced API
 
-## Install deps
+[![CircleCI](https://circleci.com/gh/retracedhq/api.svg?style=svg&circle-token=1fd99e91a465e3eda84004605dd836790564e43f)](https://circleci.com/gh/retracedhq/api) [![Code Climate](https://codeclimate.com/repos/58e520bd2a0fec02980000a1/badges/f25b410f9e0a4b58e54b/gpa.svg)](https://codeclimate.com/repos/58e520bd2a0fec02980000a1/feed) [![Coverage Status](https://coveralls.io/repos/github/retracedhq/api/badge.svg?t=smZdfc)](https://coveralls.io/github/retracedhq/api)
+
+Key responsibilities of the retraced API include:
+
+- Receiving and storing CreateEvent requests
+- Creating ViewerTokens to power the embeded `logs` viewer
+- Responding to queiries from embedded `logs` with results from Elasticsearch
+- Probably some EITAPI stuff
+- Handle Auth0 login callback
+- Tokens, stats, etc.
+
+## Usage
+#### Install deps
 > `yarn`
 
-## Run server
-> `make run`
+#### Run server
+> `make build run`
 
-## Run tests
+#### Run tests
 > `yarn test`
+
+#### Running with [Composer](https://github.com/retracedhq/composer)
+
+> `docker-compose -f ../composer/docker-compose.yml up api`

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,9 @@
 machine:
+  environment:
+    MOCHA_FILE: "$CIRCLE_TEST_REPORTS/test-results.xml"
+    PROJECT_NAME: retraced-staging
+    CLUSTER_NAME: retraced-staging
+    CLOUDSDK_COMPUTE_ZONE: us-east1-b
   services:
     - docker
   pre:
@@ -13,11 +18,10 @@ dependencies:
     - yarn
 
 test:
-  pre:
-    - yarn global add tslint@4.5.1 typescript@2.2.1 codeclimate-test-reporter
-    - make build
+  override:
+    - yarn test
   post:
-    - codeclimate-test-reporter < ./coverage/lcov.info
+    - yarn report-coverage
 
 deployment:
   docker:
@@ -27,3 +31,5 @@ deployment:
       - sudo docker build -f deploy/Dockerfile -t quay.io/retracedhq/api:${CIRCLE_SHA1:0:7} .
       - sudo docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - sudo docker push quay.io/retracedhq/api:${CIRCLE_SHA1:0:7}
+      - ./deploy/deploy_k8s_using_env.sh
+

--- a/deploy/deploy_k8s_using_env.sh
+++ b/deploy/deploy_k8s_using_env.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# CircleCI kubernetes deploy script
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo Deploying to GKE:
+echo PROJECT_NAME=$PROJECT_NAME
+echo CLUSTER_NAME=$CLUSTER_NAME
+echo CLOUDSDK_COMPUTE_ZONE=$CLOUDSDK_COMPUTE_ZONE
+echo CIRCLE_SHA1=$CIRCLE_SHA1
+echo IMAGE_TAG=${CIRCLE_SHA1:0:7}
+
+function gcloud_cli() {
+    sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update --version 120.0.0
+    sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update --version 120.0.0 kubectl
+
+    echo $GCLOUD_ACCOUNT_JSON | base64 --decode -i > ${HOME}/account.json
+    sudo /opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file ${HOME}/account.json
+
+    sudo /opt/google-cloud-sdk/bin/gcloud config set project $PROJECT_NAME
+    sudo /opt/google-cloud-sdk/bin/gcloud --quiet config set container/cluster $CLUSTER_NAME
+    sudo /opt/google-cloud-sdk/bin/gcloud config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}
+    sudo /opt/google-cloud-sdk/bin/gcloud --quiet container clusters get-credentials $CLUSTER_NAME
+}
+
+
+function template_yamls() {
+    rm -rf build/k8s
+    mkdir -p build/k8s
+    yarn global add handlebars-cmd
+    set -v
+    handlebars --tag ${CIRCLE_SHA1:0:7} < deploy/k8s/api-deployment.yml.hbs > build/k8s/api-deployment.yml
+    handlebars                          < deploy/k8s/api-service.yml.hbs    > build/k8s/api-service.yml
+    handlebars                          < deploy/k8s/api-ingress.yml.hbs    > build/k8s/api-ingress.yml
+    set +v
+}
+
+function chown_home() {
+    sudo chown -R ubuntu:ubuntu /home/ubuntu/.kube
+}
+
+function ship_it() {
+    kubectl apply -f build/k8s/
+}
+
+gcloud_cli
+template_yamls
+chown_home
+ship_it 
+

--- a/deploy/k8s/api-deployment.yml.hbs
+++ b/deploy/k8s/api-deployment.yml.hbs
@@ -1,0 +1,135 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: retraced
+        tier: api
+    spec:
+      imagePullSecrets:
+        - name: quayio
+      containers:
+        - name: api
+          image: quay.io/retracedhq/api:{{ tag }}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: REDIS_URI
+              valueFrom:
+                secretKeyRef:
+                  name: redis
+                  key: REDIS_URI
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_PORT
+            - name: POSTGRES_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: POSTGRES_DATABASE
+            - name: SCYLLA_HOSTS
+              valueFrom:
+                secretKeyRef:
+                  name: scylla
+                  key: SCYLLA_HOSTS
+            - name: SCYLLA_KEYSPACE
+              valueFrom:
+                secretKeyRef:
+                  name: scylla
+                  key: SCYLLA_KEYSPACE
+            - name: SCYLLA_USER
+              valueFrom:
+                secretKeyRef:
+                  name: scylla
+                  key: SCYLLA_USER
+            - name: SCYLLA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: scylla
+                  key: SCYLLA_PASSWORD
+            - name: HMAC_SECRET_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: jwt
+                  key: HMAC_SECRET_ADMIN
+            - name: HMAC_SECRET_VIEWER
+              valueFrom:
+                secretKeyRef:
+                  name: jwt
+                  key: HMAC_SECRET_VIEWER
+            - name: RETRACED_APP_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: retraced
+                  key: RETRACED_APP_BASE
+            - name: MANDRILL_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mandrill
+                  key: MANDRILL_KEY
+            - name: ELASTICSEARCH_NODES
+              valueFrom:
+                secretKeyRef:
+                  name: elasticsearch
+                  key: ELASTICSEARCH_NODES
+            - name: DISQUE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: disque
+                  key: DISQUE_PASSWORD
+            - name: DISQUE_NODES
+              valueFrom:
+                secretKeyRef:
+                  name: disque
+                  key: DISQUE_NODES
+            - name: AUTH0_CLIENT_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: auth0
+                  key: AUTH0_CLIENT_DOMAIN
+            - name: AUTH0_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: auth0
+                  key: AUTH0_CLIENT_ID
+            - name: RETRACED_PUBLIC_SITE
+              valueFrom:
+                secretKeyRef:
+                  name: retraced
+                  key: RETRACED_PUBLIC_SITE
+            - name: STATUSPAGEIO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: statuspageio
+                  key: token
+            - name: BUGSNAG_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: bugsnag
+                  key: API_TOKEN
+            - name: BUGSNAG_STAGE
+              valueFrom:
+                secretKeyRef:
+                  name: bugsnag
+                  key: STAGE

--- a/deploy/k8s/api-ingress.yml.hbs
+++ b/deploy/k8s/api-ingress.yml.hbs
@@ -1,0 +1,10 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: api-ingress
+spec:
+  tls:
+    - secretName: api-tls
+  backend:
+    serviceName: api
+    servicePort: 80

--- a/deploy/k8s/api-service.yml.hbs
+++ b/deploy/k8s/api-service.yml.hbs
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  labels:
+    app: retraced
+    tier: api
+spec:
+  type: NodePort
+  ports:
+  - name: svcmain
+    port: 80
+    targetPort: 3000
+  selector:
+    app: retraced
+    tier: api

--- a/package.json
+++ b/package.json
@@ -47,13 +47,16 @@
     "@types/lodash": "^4.14.54",
     "@types/request": "^0.0.42",
     "chance": "^1.0.6",
+    "coveralls": "^2.13.0",
     "istanbul": "1.1.0-alpha.1",
+    "mocha-junit-reporter": "^1.13.0",
     "tslint": "^4.5.1",
     "typescript": "^2.2.1"
   },
   "scripts": {
-    "pretest": "tsc",
-    "test": "istanbul cover _mocha -- build/test/*.js"
+    "pretest": "tslint --project ./tsconfig.json && tsc -p .",
+    "test": "istanbul cover _mocha --report lcovonly -- --reporter mocha-junit-reporter build/test/*.js",
+    "report-coverage": "coveralls < ./coverage/lcov.info && codeclimate-test-reporter < ./coverage/lcov.info"
   },
   "author": "",
   "license": "ISC",

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,6 +534,10 @@ chance@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/chance/-/chance-1.0.6.tgz#4734f62d02b738cdc2882d8b5d41f89af49e7bfd"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -679,6 +683,16 @@ cors@^2.8.1:
     object-assign "^4"
     vary "^1"
 
+coveralls@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.0.tgz#df933876e8c6f478efb04f4d3ab70dc96b7e5a8e"
+  dependencies:
+    js-yaml "3.6.1"
+    lcov-parse "0.0.10"
+    log-driver "1.2.5"
+    minimist "1.2.0"
+    request "2.79.0"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -698,6 +712,10 @@ cross-spawn@^4:
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -944,7 +962,7 @@ esprima@3.x.x, esprima@^3.1.1, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-esprima@^2.7.1:
+esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -1117,7 +1135,7 @@ forever-agent@^0.6.0, forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@^2.1.1:
+form-data@^2.1.1, form-data@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
   dependencies:
@@ -1234,7 +1252,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.0.5:
+glob@7.0.5, glob@^7.0.3:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
   dependencies:
@@ -1255,7 +1273,7 @@ glob@^5.0.15, glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
+glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1454,7 +1472,7 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
-is-buffer@^1.0.2:
+is-buffer@^1.0.2, is-buffer@~1.1.1:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
@@ -1687,6 +1705,13 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+js-yaml@3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
+
 js-yaml@3.x, js-yaml@^3.7.0:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.2.tgz#02d3e2c0f6beab20248d412c352203827d786721"
@@ -1878,6 +1903,10 @@ lodash@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.5.0.tgz#19bb3f4d51278f0b8c818ed145c74ecf9fe40e6d"
 
+log-driver@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
 long@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
@@ -1924,6 +1953,14 @@ md5-hex@^1.2.0:
 md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
+md5@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1989,7 +2026,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1997,11 +2034,20 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mocha-junit-reporter@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.13.0.tgz#030db8c530b244667253b03861d4cd336f7e56c8"
+  dependencies:
+    debug "^2.2.0"
+    md5 "^2.1.0"
+    mkdirp "~0.5.1"
+    xml "^1.0.0"
 
 mocha-typescript@^1.0.23:
   version "1.0.23"
@@ -2464,6 +2510,10 @@ qs@~6.2.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
 
+qs@~6.3.0:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -2663,6 +2713,31 @@ request@2, request@2.x, request@~2.74.0:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
+
+request@2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -3214,7 +3289,7 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@3.0.0:
+uuid@3.0.0, uuid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
@@ -3320,6 +3395,10 @@ xml2js@0.4.15:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder ">=2.4.6"
+
+xml@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
 
 xmlbuilder@2.6.2, xmlbuilder@>=2.4.6:
   version "2.6.2"


### PR DESCRIPTION
This uses the env var `GCLOUD_ACCOUNT_JSON` in circleci
for authentication. Its base64-encoded json from the google cloud console.

We use the npm package `handlebars-cmd` to template the files from
`deploy/k8s` into `build/k8s`, then use `kubectl apply -f ./build/k8s`
to ship the configs.

For now the only templated value is `--tag ${CIRCLE_SHA1:0:7}` in the
`api-deployment.yml.hbs`, but we pipe the ingress and service through
handlebars as well.

Also some other random circle stuff:
    - move coverage reporting to a yarn script
    - set up coverage   reporting to coveralls.
    - have mocha output test-results.xml which circle can find it