### PR TITLE
Add circuit breaker to DisqueClient

### DIFF
--- a/src/persistence/disque.ts
+++ b/src/persistence/disque.ts
@@ -1,35 +1,51 @@
 import * as hiredis from "hiredis";
 import * as _ from "lodash";
-import * as net from "net";
-import { instrumented } from "monkit";
+import * as util from "util";
+import { instrumented, meter, timer, histogram } from "monkit";
 
 let sharedClient;
 
 export default function getDisque() {
   if (!sharedClient) {
-    sharedClient = new DisqueClient();
+    sharedClient = DisqueClient.newClientFromEnv();
   }
 
   return sharedClient;
 }
 
 export class DisqueClient {
-  private nodes: any[];
-  private password: string;
-  private hiredisSocket: any;
-  private pendingOps: any[];
 
-  constructor() {
-    this.nodes = [];
+  public static newClientFromEnv(): DisqueClient {
+    const nodes: any[] = [];
     _.split(process.env.DISQUE_NODES, ",").forEach((n) => {
       const parts = n.split(":");
-      this.nodes.push({
+      nodes.push({
         host: parts[0],
         port: parts[1],
       });
     });
+    const password = process.env.DISQUE_PASSWORD;
+    const circuitBreakerThreshold = process.env.DISQUE_CIRCUIT_BREAKER_THRESHOLD;
+    return new DisqueClient(nodes, password, Number(circuitBreakerThreshold));
+  }
 
-    this.password = process.env.DISQUE_PASSWORD;
+  private nodes: any[];
+  private password?: string;
+  private hiredisSocket: any;
+  private pendingOps: any[];
+  private circuitBreakerThreshold: number;
+
+  /**
+   * @param nodes                   a list of {host, port} objects
+   * @param password                optional disque password
+   * @param circuitBreakerThreshold optional error threshold. If the percent of errors is higher than this value,
+   *                                the connection will be destroyed and reconnected.
+   *                                values outside the range [0, 1] will be ignored
+   */
+  constructor(nodes: any[], password?: string, circuitBreakerThreshold?: number) {
+    this.nodes = nodes;
+    this.password = password;
+    this.circuitBreakerThreshold = circuitBreakerThreshold || -1;
   }
 
   @instrumented
@@ -44,7 +60,7 @@ export class DisqueClient {
     return this.send(cmd);
   }
 
-  private connect() {
+  private async connect(): Promise<void> {
     if (this.hiredisSocket) {
       return;
     }
@@ -57,6 +73,7 @@ export class DisqueClient {
       .on("reply", (data) => {
         if (data instanceof Error) {
           this.pendingOps.shift().reject(data);
+          this.checkCircuitBreaker();
         } else {
           this.pendingOps.shift().resolve(data);
         }
@@ -69,17 +86,18 @@ export class DisqueClient {
       })
       .on("close", (hadError) => {
         this.hiredisSocket = null;
-        console.log("Disque connection was closed.");
+        console.log("Disque connection was closed. `hadError` was ", hadError);
       });
 
     if (this.password) {
-      this.auth(this.password);
+      await this.auth(this.password);
     }
   }
 
-  private async send(args) {
+  @instrumented
+  private async send(args): Promise<string> {
     this.connect();
-    return new Promise((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
       this.pendingOps.push({ resolve, reject });
       this.hiredisSocket.write.apply(this.hiredisSocket, args);
     });
@@ -89,4 +107,44 @@ export class DisqueClient {
     return this.send(["AUTH", password]);
   }
 
+  // we maybe want to use something like hystrixjs,
+  // but it seems a little heavy for what we need at this point.
+  private checkCircuitBreaker() {
+    const shouldCheck =
+        this.circuitBreakerThreshold >= 0 &&
+        this.circuitBreakerThreshold <= 1 &&
+        !this.hiredisSocket.destroyed;
+
+    if (!shouldCheck) {
+      return;
+    }
+
+    const errorPct = this.computeErrorPercentage();
+    histogram("DisqueClient.send.errorPct").update(errorPct);
+
+    if (errorPct > this.circuitBreakerThreshold) {
+      this.forceReconnect(errorPct);
+    }
+  }
+
+  private computeErrorPercentage() {
+    const errorRate = meter("DisqueClient.send.errors").fifteenMinuteRate();
+    const callRate  = timer("DisqueClient.send.timer").fifteenMinuteRate();
+    const errorPct = callRate ? (errorRate / callRate) : 0;
+    return errorPct;
+  }
+
+  /**
+   * Destroy the disque socket, forcing a reconnect
+   * on the next operation.
+   */
+  private forceReconnect(errorPct: number) {
+      console.log(`Error Percentage ${errorPct} is greater than threshold` +
+                  `${this.checkCircuitBreaker}, reconnecting to disque at` +
+                  `${util.inspect(this.nodes[0])}`);
+      meter("DisqueClient.forceReconnect.destroy").mark();
+      if (!this.hiredisSocket.destroyed) {
+        this.hiredisSocket.destroy();
+      }
+  }
 }


### PR DESCRIPTION
Disque client now reads and stores an optional `DISQUE_CIRCUIT_BREAKER_THRESHOLD`.

On an error from Disque during the `reply` event, client will check
the percentage of recent errors and force a reconnect if it is above
this threshold.