### PR TITLE
super rough take of using TSOA for swagger docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 lib/
+java/
 
 *.DS_Store
 .AppleDouble
@@ -85,3 +86,4 @@ jspm_packages
 
 # mocha-junit-reporter
 test-results.xml
+

--- a/README.md
+++ b/README.md
@@ -24,3 +24,36 @@ Key responsibilities of the retraced API include:
 #### Running with [Composer](https://github.com/retracedhq/composer)
 
 > `docker-compose -f ../composer/docker-compose.yml up api`
+
+
+## Swagger Documentation
+
+Swagger spec is generated from source using [TSOA](https://github.com/lukeautry/tsoa)
+
+By default, a swagger spec is built as part of `make build`, and is served by express at `/publisher/v1/swagger.json`.
+
+In staging/production, these specs are fed to [readme.io](https://readme.io), but it is possible to generate/preview them locally.
+
+
+#### Generating a spec
+
+To generate swagger.json from Typescript sources use
+
+```
+make swagger
+```
+
+The outputs will be written to build/swagger.json
+
+#### Previewing a spec
+
+The first time you generate markup, you will need to `make markup-deps` to install tooling.
+
+Then you can 
+
+```
+make markup-docs
+```
+
+which will build `build/swagger.adoc`, convert to `build/swagger.html`, and open using `google-chrome`
+

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,6 @@ dependencies:
 test:
   override:
     - yarn cover-xml
-  post:
     - yarn report-coverage
 
 deployment:

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "swagger-jsdoc": "^1.9.2",
     "threads": "^0.7.2",
     "ts-node": "^1.7.0",
+    "tsoa": "^1.1.7",
     "uuid": "^2.0.2"
   },
   "devDependencies": {
@@ -70,7 +71,6 @@
     "report-coverage": "coveralls < ./coverage/lcov.info && codeclimate-test-reporter < ./coverage/lcov.info"
   },
   "author": "",
-  "license": "ISC",
   "nyc": {
     "include": [
       "lib/**/*.js"

--- a/src/controllers/PublisherController.ts
+++ b/src/controllers/PublisherController.ts
@@ -1,0 +1,34 @@
+import { Get, Post, Route, Body, Query, Header, Path, SuccessResponse, Controller, Example } from "tsoa";
+
+import { RetracedEvent } from "../models/event/";
+import {EventCreater, CreateEventResult} from "../handlers/createEvent";
+
+@Route("publisher/v1")
+export class PublisherController extends Controller {
+
+    private readonly eventCreater: EventCreater;
+
+    constructor(eventCreater: EventCreater) {
+        super();
+        this.eventCreater = eventCreater;
+    }
+
+    @Post("project/{projectId}/event")
+    @SuccessResponse("201", "Created")
+    @Example<CreateEventResult>({
+        id: "abf053dc4a3042459818833276eec717",
+        hash: "5b570bff4628b35262fb401d2f6c9bb38d29e212f6e0e8ea93445b4e5a253d50",
+    })
+    public async createEvent(
+        @Header("Authorization") auth: string,
+        @Path("projectId") projectId: string,
+        @Body() event: RetracedEvent,
+    ): Promise<CreateEventResult> {
+
+        const result: any = await this.eventCreater.createEvent(auth, projectId, event);
+
+        this.setStatus(result.status);
+        return Promise.resolve(result.body);
+
+    }
+}

--- a/src/defs.d.ts
+++ b/src/defs.d.ts
@@ -1,1 +1,5 @@
 declare module "csv-stringify";
+declare module "*.json" {
+    const value: any;
+    export default value;
+}

--- a/src/models/event/canonicalize.ts
+++ b/src/models/event/canonicalize.ts
@@ -33,7 +33,7 @@ export default function (event: Event): string {
   }
 
   let canonicalString = "";
-  canonicalString += `${encodePassOne(event.id)}:`;
+  canonicalString += `${encodePassOne(event.id!)}:`;
   canonicalString += `${encodePassOne(event.action)}:`;
   canonicalString += _.isEmpty(event.target) ? ":" : `${encodePassOne(event.target!.id)}:`;
   canonicalString += _.isEmpty(event.actor) ? ":" : `${encodePassOne(event.actor!.id)}:`;

--- a/src/models/event/index.ts
+++ b/src/models/event/index.ts
@@ -1,35 +1,47 @@
-interface Event {
-  id: string;
-  action: string;
-  group?: {
-    id: string;
-    name?: string;
-  };
 
+export interface Group {
+  id: string;
+  name?: string;
+}
+
+export interface Actor {
+  id: string;
+  name?: string;
+  href?: string;
+}
+
+export interface Target {
+  id: string;
+  name: string;
+  href?: string;
+  type?: string;
+}
+
+export interface Fields {
+  [key: string]: string;
+}
+
+export type crud = "c" | "r" | "u" | "d";
+
+export interface RetracedEvent {
+  id?: string;
+  action: string;
+  group?: Group;
   displayTitle?: string;
   created?: number;
-  actor?: {
-    id: string;
-    name: string;
-    href?: string;
-  };
-  target?: {
-    id: string;
-    name: string;
-    href?: string;
-    type?: string;
-  };
-  crud?: "c" | "r" | "u" | "d";
+  actor?: Actor;
+  target?: Target;
+  crud?: crud;
   sourceIp?: string;
   description?: string;
   isAnonymous?: boolean;
   isFailure?: boolean;
-  fields?: { [key: string]: string };
+  fields?: Fields;
 }
 
-export default Event;
+export default RetracedEvent;
 
-export function fromCreateEventInput(eventInput: any, newEventId: string): Event {
+export function fromCreateEventInput(eventInput: any, newEventId: string): RetracedEvent {
   return {
     id: newEventId,
     action: eventInput["action"],

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,99 @@
+import * as _ from "lodash";
+import * as bugsnag from "bugsnag";
+import * as chalk from "chalk";
+import * as express from "express";
+import * as util from "util";
+import * as uuid from "uuid";
+
+export const onSuccess = (res: express.Response, reqId: string, statusCode?: number) => (result: any) => {
+
+  if (result) {
+
+    const statusToSend = result.status || statusCode || 200;
+    const body = result.body || JSON.stringify(result);
+    const contentType = result.contentType || "application/json";
+
+    let bodyToLog = body;
+    if (!bodyToLog) {
+      bodyToLog = "";
+    } else if (bodyToLog.length > 512) {
+      bodyToLog = `${bodyToLog.substring(0, 512)} (... truncated, total ${bodyToLog.length} bytes)`;
+    }
+    console.log(chalk.cyan(`[${reqId}] => ${result.status} ${bodyToLog}`));
+    const respObj = res.status(statusToSend).type(contentType).set("X-Retraced-RequestId", reqId);
+    if (result.filename) {
+      respObj.attachment(result.filename);
+    }
+    if (result.headers) {
+      _.forOwn(result.headers, (value, key) => {
+        respObj.set(key!, value);
+      });
+    }
+    respObj.send(body);
+  } else {
+    // Generic response. Shouldn't happen in most cases, but...
+    console.log(chalk.cyan(`[${reqId}] => 200`));
+    res.status(200).set("X-Retraced-RequestId", reqId).json(result);
+  }
+};
+
+export const onError = (res: express.Response, reqId: string) => (err: any) => {
+
+  bugsnag.notify(err);
+  if (err.status) {
+    // Structured error, specific status code.
+    const errMsg = err.err ? err.err.message : "An unexpected error occurred";
+    console.log(chalk.red(`[${reqId}] !! ${err.status} ${errMsg} ${err.stack || util.inspect(err)}`));
+    const bodyToSend = {
+      error: errMsg,
+    };
+    res.status(err.status).set("X-Retraced-RequestId", reqId).json(bodyToSend);
+  } else {
+    // Generic error, default code (500).
+    const bodyToSend = {
+      error: err.message || "An unexpected error occurred",
+    };
+    console.log(chalk.red(`[${reqId}] !! 500 ${err.stack || err.message || util.inspect(err)}`));
+    res.status(500).set("X-Retraced-RequestId", reqId).json(bodyToSend);
+  }
+};
+
+export const preRequest = (req: express.Request, reqId: string) => {
+  console.log(chalk.yellow(`[${reqId}] <- ${req.method} ${req.originalUrl}`));
+  if (!_.isEmpty(req.body)) {
+    let bodyString = JSON.stringify(req.body);
+    if (bodyString.length > 512) {
+      bodyString = `${bodyString.substring(0, 512)} (... truncated, total ${bodyString.length} bytes)`;
+    }
+    console.log(chalk.yellow(`[${reqId}] <- ${bodyString}`));
+  }
+};
+
+export const requestId = (req: express.Request, handlerName: string) => {
+  return `${handlerName}:${uuid.v4().replace("-", "").substring(0, 8)}`;
+};
+
+export const wrapRoute = (route, handlerName) =>
+  (req: express.Request, res: express.Response) => {
+    const reqId = requestId(req, handlerName);
+    preRequest(req, reqId);
+    route.handler(req)
+      .then(onSuccess(res, reqId))
+      .catch(onError(res, reqId));
+};
+
+export function register(route, handler, app) {
+  // Register this route and callback with express.
+  console.log(`[${route.method}] '${route.path}'`);
+  if (route.method === "get") {
+    app.get(route.path, handler);
+  } else if (route.method === "post") {
+    app.post(route.path, handler);
+  } else if (route.method === "put") {
+    app.put(route.path, handler);
+  } else if (route.method === "delete") {
+    app.delete(route.path, handler);
+  } else {
+    console.log(`Unhandled HTTP method: '${route.method}'`);
+  }
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -52,14 +52,7 @@ import viewerUpdateEitapiToken from "./handlers/viewer/updateEitapiToken";
 import viewerUpdateExport from "./handlers/viewer/updateExport";
 
 export default {
-  //
-  // publisher
-  //
-  publisherCreateEvent: {
-    path: "/publisher/v1/project/:projectId/event",
-    method: "post",
-    handler: createEvent,
-  },
+
   pulisherCreateViewerDescriptor: {
     path: "/publisher/v1/project/:projectId/viewertoken",
     method: "get",
@@ -313,9 +306,12 @@ export default {
     handler: enterpriseSearchAdHoc,
   },
 
+//
   //
-  // OLD ROUTES -- DONT DOCUMENT, DEPRECATE SOON
-  //
+    // OLD ROUTES -- DONT DOCUMENT, DEPRECATE SOON
+      //
+        //
+          //
 
   //
   // core
@@ -324,11 +320,6 @@ export default {
     path: "/v1/user/login",
     method: "post",
     handler: createAdminSession,
-  },
-  createEvent: {
-    path: "/v1/project/:projectId/event",
-    method: "post",
-    handler: createEvent,
   },
   createViewerDescriptor: {
     path: "/v1/project/:projectId/viewertoken",
@@ -583,3 +574,7 @@ export default {
     handler: viewerUpdateExport,
   },
 };
+
+export function LegacyRoutes() {
+  return exports.default;
+}

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,25 +1,13 @@
 // tslint:disable-next-line
-const swaggerJSDoc = require("swagger-jsdoc");
 import * as util from "util";
+import * as publisherApi from "./swagger.json";
 
 const apiHost = process.env.RETRACED_API_BASE || "localhost:3000";
 
-const publisher = {
-  info: {
-    title: "Publisher API",
-    version: "1.0.0",
-    description: "Public API for publishing events and creating viewer descriptors",
-  },
-  host: apiHost,
-  basePath: "/publisher/v1",
-};
+function fix(json: any): void {
+  json.host = apiHost;
+}
 
-const options = {
-  swaggerDefinition: publisher,
-  apis: ["./build/handlers/createEvent.js", "./build/handlers/createViewerDescriptor.js"],
-};
+fix(publisherApi);
 
-const publisherSpec = swaggerJSDoc(options);
-console.log(util.inspect(publisherSpec, false, 100 , true));
-
-export { publisherSpec };
+export { publisherApi };

--- a/src/test/handlers/createEvent.ts
+++ b/src/test/handlers/createEvent.ts
@@ -63,7 +63,7 @@ import { EventCreater } from "../../handlers/createEvent";
             fakeUUID,
         );
 
-        const resp: any = await creater.createEvent(request.object);
+        const resp: any = await creater.createEventRaw(request.object);
 
         expect(resp.status).to.equal(201);
         const responseBody = JSON.parse(resp.body);

--- a/src/tsoa_routes.ts
+++ b/src/tsoa_routes.ts
@@ -1,0 +1,61 @@
+import * as _ from "lodash";
+import * as bugsnag from "bugsnag";
+import * as chalk from "chalk";
+import * as express from "express";
+import * as util from "util";
+import * as uuid from "uuid";
+
+import { Controller } from "tsoa";
+
+import { PublisherController } from "./controllers/PublisherController";
+import { defaultEventCreater } from "./handlers/createEvent";
+import { wrapRoute, register, requestId, preRequest, onSuccess, onError } from "./router";
+
+interface TSOARoute {
+  path: string;
+  method: string;
+  controller: object;
+  controllerMethod: (...args: any[]) => any;
+  argsFrom: (request: express.Request) => any[];
+}
+
+interface TSOARoutes {
+  [name: string]: TSOARoute;
+}
+
+export function TSOARoutes(publisherController?: PublisherController): TSOARoutes {
+  publisherController = publisherController || new PublisherController(defaultEventCreater);
+  return {
+    createEvent: {
+      path: "/v1/project/:projectId/event",
+      method: "post",
+      controller: publisherController,
+      controllerMethod: publisherController.createEvent,
+      argsFrom: (request: express.Request) => [request.get("Authorization"), request.params.projectId, request.body],
+    },
+    publisherCreatedEvent: {
+      path: "/publisher/v1/project/:projectId/event",
+      method: "post",
+      controller: publisherController,
+      controllerMethod: publisherController.createEvent,
+      argsFrom: (request: express.Request) => [request.get("Authorization"), request.params.projectId, request.body],
+    },
+  };
+}
+
+export const wrapTSOARoute = (route: TSOARoute, handlerName: string) =>
+  (request: express.Request, response: any, next: any) => {
+
+    const reqId = requestId(request, handlerName);
+    preRequest(request, reqId);
+
+    const promise = route.controllerMethod.apply(route.controller, route.argsFrom(request));
+    let statusCode: number | undefined;
+    if (route.controller instanceof Controller) {
+      statusCode = (route.controller as Controller).getStatus();
+    }
+
+    promise
+      .then(onSuccess(response, reqId, statusCode))
+      .catch(onError(response, reqId));
+  };

--- a/tsoa.json
+++ b/tsoa.json
@@ -1,0 +1,8 @@
+{
+    "swagger": {
+        "outputDirectory": "./build",
+        "entryFile": "./src/index.ts",
+        "host": "localhost:3000",
+        "basePath": "/publisher/v1"
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,11 +195,24 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@~0.1.15:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
+  dependencies:
+    underscore "~1.7.0"
+    underscore.string "~2.4.0"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
   dependencies:
     arr-flatten "^1.0.1"
+
+arr-filter@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/arr-filter/-/arr-filter-1.1.2.tgz#43fdddd091e8ef11aa4c45d9cdc18e2dff1711ee"
+  dependencies:
+    make-iterator "^1.0.0"
 
 arr-flatten@^1.0.1:
   version "1.0.1"
@@ -208,6 +221,13 @@ arr-flatten@^1.0.1:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-sort@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/array-sort/-/array-sort-0.1.2.tgz#aea6fc9253f33fae7e8c35b02004b381ad0d6433"
+  dependencies:
+    get-value "^2.0.5"
+    kind-of "^2.0.0"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -284,6 +304,10 @@ auth0-js@^8.0.4:
     superagent "^3.3.1"
     url-join "^1.1.0"
     winchan "^0.2.0"
+
+autolinker@~0.15.0:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.15.3.tgz#342417d8f2f3461b14cf09088d5edf8791dc9832"
 
 aws-sdk@^2.6.12:
   version "2.34.0"
@@ -415,6 +439,10 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@^3.0.5:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 body-parser@^1.15.2:
   version "1.17.1"
@@ -669,6 +697,10 @@ commander@2.9.0, commander@^2.5.0, commander@^2.7.1, commander@^2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commandpost@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commandpost/-/commandpost-1.0.1.tgz#7d7e3e69ae8fe7d6949341e91596ede9b2d631fd"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -769,6 +801,15 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+create-frame@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/create-frame/-/create-frame-1.0.0.tgz#8b95f2691e3249b6080443e33d0bad9f8f6975aa"
+  dependencies:
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    isobject "^3.0.0"
+    lazy-cache "^2.0.2"
+
 cross-spawn-async@^2.1.1:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
@@ -842,9 +883,22 @@ data-uri-to-buffer@0:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz#46e13ab9da8e309745c8d01ce547213ebdb2fe3f"
 
-debug@2, debug@2.6.1, debug@^2.2.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+date.js@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/date.js/-/date.js-0.3.1.tgz#39e7c7c77adc765d10becf496cacd391332d7cc8"
+  dependencies:
+    debug "~0.7.2"
+    lodash.filter "^4.2.0"
+    lodash.findkey "^4.2.0"
+    lodash.foreach "^4.1.0"
+    lodash.includes "^4.1.0"
+    lodash.isempty "^4.1.2"
+    lodash.partition "^4.2.0"
+    lodash.trim "^4.2.0"
+
+debug@2, debug@2.6.3, debug@^2.2.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
 
@@ -854,11 +908,15 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
+debug@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
     ms "0.7.2"
+
+debug@~0.7.2:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -883,6 +941,12 @@ default-require-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
   dependencies:
     strip-bom "^2.0.0"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
 
 defined@^1.0.0:
   version "1.0.0"
@@ -988,6 +1052,15 @@ ecdsa-sig-formatter@1.0.9:
     base64url "^2.0.0"
     safe-buffer "^5.0.1"
 
+editorconfig@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.2.tgz#8e57926d9ee69ab6cb999f027c2171467acceb35"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    sigmund "^1.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1005,6 +1078,10 @@ elasticsearch@^11.0.1:
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
+
+ent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -1086,7 +1163,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-express@^4.14.0:
+express@^4.14.0, express@^4.14.1:
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.2.tgz#af107fc148504457f2dca9a6f2571d7129b97b35"
   dependencies:
@@ -1118,6 +1195,12 @@ express@^4.14.0:
     type-is "~1.6.14"
     utils-merge "1.0.0"
     vary "~1.1.0"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
 
 extend@3, extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
@@ -1195,7 +1278,11 @@ findup-sync@~0.3.0:
   dependencies:
     glob "~5.0.0"
 
-for-in@^1.0.1:
+for-in@^0.1.6:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
+
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -1247,6 +1334,10 @@ forwarded@~0.1.0:
 fresh@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
+
+fs-exists-sync@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1314,6 +1405,13 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-object@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/get-object/-/get-object-0.2.0.tgz#d92ff7d5190c64530cda0543dac63a3d47fe8c0c"
+  dependencies:
+    is-number "^2.0.2"
+    isobject "^0.2.0"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -1328,6 +1426,10 @@ get-uri@1:
     file-uri-to-path "0"
     ftp "~0.3.5"
     readable-stream "2"
+
+get-value@^2.0.5, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -1425,9 +1527,53 @@ handlebars-cmd@^0.1.4:
     handlebars "~1.0.10"
     optimist "~0.3.5"
 
-handlebars@4.0.5, handlebars@^4.0.3:
+handlebars-helpers@^0.8.0:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/handlebars-helpers/-/handlebars-helpers-0.8.2.tgz#8e0db7d8a9184b255723213216aa668742a0a4dd"
+  dependencies:
+    arr-filter "^1.1.1"
+    arr-flatten "^1.0.1"
+    array-sort "^0.1.2"
+    create-frame "^1.0.0"
+    define-property "^0.2.5"
+    for-in "^0.1.6"
+    for-own "^0.1.4"
+    get-object "^0.2.0"
+    get-value "^2.0.6"
+    handlebars "^4.0.6"
+    helper-date "^0.2.3"
+    helper-markdown "^0.2.1"
+    helper-md "^0.2.2"
+    html-tag "^1.0.0"
+    index-of "^0.2.0"
+    is-even "^0.1.1"
+    is-glob "^3.1.0"
+    is-number "^3.0.0"
+    is-odd "^0.1.1"
+    kind-of "^3.1.0"
+    lazy-cache "^2.0.2"
+    logging-helpers "^0.4.0"
+    make-iterator "^0.3.0"
+    micromatch "^2.3.11"
+    mixin-deep "^1.1.3"
+    normalize-path "^2.0.1"
+    relative "^3.0.2"
+    striptags "^2.1.1"
+    to-gfm-code-block "^0.1.1"
+
+handlebars@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.5.tgz#92c6ed6bb164110c50d4d8d0fbddc70806c6f8e7"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
+
+handlebars@^4.0.3, handlebars@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -1485,6 +1631,32 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+helper-date@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/helper-date/-/helper-date-0.2.3.tgz#d870cabba041d329cc856db20bb8c49674e3ef28"
+  dependencies:
+    date.js "^0.3.1"
+    extend-shallow "^2.0.1"
+    kind-of "^3.1.0"
+    moment "^2.17.1"
+
+helper-markdown@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/helper-markdown/-/helper-markdown-0.2.1.tgz#377c5924cd9d370929106a034325d7f4684bbcac"
+  dependencies:
+    isobject "^2.0.0"
+    mixin-deep "^1.1.3"
+    remarkable "^1.6.0"
+
+helper-md@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/helper-md/-/helper-md-0.2.2.tgz#c1f59d7e55bbae23362fd8a0e971607aec69d41f"
+  dependencies:
+    ent "^2.2.0"
+    extend-shallow "^2.0.1"
+    fs-exists-sync "^0.1.0"
+    remarkable "^1.6.2"
+
 hiredis@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/hiredis/-/hiredis-0.5.0.tgz#db03a98becd7003d13c260043aceecfacdf59b87"
@@ -1499,6 +1671,13 @@ hoek@2.x.x:
 hosted-git-info@^2.1.4:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.1.tgz#4b0445e41c004a8bd1337773a4ff790ca40318c8"
+
+html-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/html-tag/-/html-tag-1.0.0.tgz#95e5612aec82bea928ed44595f854145e9f7e0b5"
+  dependencies:
+    isobject "^3.0.0"
+    void-elements "^2.0.1"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -1555,6 +1734,10 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
+index-of@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/index-of/-/index-of-0.2.0.tgz#38c1e2367ea55dffad3b6eb592ec1cc3090d7d65"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1595,6 +1778,12 @@ ipaddr.js@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1615,6 +1804,21 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-descriptor@^0.1.0:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.5.tgz#e3fb8b4ab65f3a37373388e18b401d78c58cbea7"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^3.0.2"
+    lazy-cache "^2.0.2"
+
 is-dotfile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
@@ -1625,13 +1829,24 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-even@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-even/-/is-even-0.1.1.tgz#f10fbfb62d893f755d8dae8fb9a398bbc8cd5f2a"
+  dependencies:
+    is-number "^1.1.0"
+    is-odd "^0.1.0"
+
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+
+is-extglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -1655,6 +1870,12 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  dependencies:
+    is-extglob "^2.1.0"
+
 is-my-json-valid@^2.12.4:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
@@ -1668,15 +1889,31 @@ is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
+is-number@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-1.1.2.tgz#9d82409f3a8a8beecf249b1bc7dada49829966e4"
+
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  dependencies:
+    kind-of "^3.0.2"
+
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
+is-odd@^0.1.0, is-odd@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-0.1.1.tgz#51508f7d39eafb0282fbb98957b2d1d28e72a3e7"
+  dependencies:
+    is-number "^1.1.0"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -1726,11 +1963,19 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
+isobject@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-0.2.0.tgz#a3432192f39b910b5f02cc989487836ec70aa85e"
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.0.tgz#39565217f3661789e8a0a0c080d5f7e6bc46e1a0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -1942,7 +2187,13 @@ jws@^3.1.4:
     jwa "^1.1.4"
     safe-buffer "^5.0.1"
 
-kind-of@^3.0.2:
+kind-of@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
+  dependencies:
+    is-buffer "^1.0.2"
+
+kind-of@^3.0.2, kind-of@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
   dependencies:
@@ -1957,6 +2208,12 @@ latest-version@^3.0.0:
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lazy-cache@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
+  dependencies:
+    set-getter "^0.1.0"
 
 lazy-req@^2.0.0:
   version "2.0.0"
@@ -2024,9 +2281,25 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.filter@^4.2.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+
+lodash.findkey@^4.2.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.findkey/-/lodash.findkey-4.6.0.tgz#83058e903b51cbb759d09ccf546dea3ea39c4718"
+
+lodash.foreach@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
 lodash.get@^4.0.0, lodash.get@^4.1.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.includes@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -2035,6 +2308,10 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isempty@^4.1.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
 lodash.isequal@^4.4.0:
   version "4.5.0"
@@ -2052,6 +2329,14 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
+lodash.partition@^4.2.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.partition/-/lodash.partition-4.6.0.tgz#a38e46b73469e0420b0da1212e66d414be364ba4"
+
+lodash.trim@^4.2.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash.trim/-/lodash.trim-4.5.1.tgz#36425e7ee90be4aa5e27bcebb85b7d11ea47aa57"
+
 lodash@^3.10.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -2067,6 +2352,12 @@ lodash@~3.5.0:
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
+logging-helpers@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/logging-helpers/-/logging-helpers-0.4.0.tgz#00e6d5316c23767ec12e1200e4f12c5e033e7eb0"
+  dependencies:
+    chalk "^1.0.0"
 
 long@^2.2.0:
   version "2.4.0"
@@ -2086,6 +2377,12 @@ lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
+
 lru-cache@^4.0.0, lru-cache@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
@@ -2100,6 +2397,18 @@ lru-cache@~2.6.5:
 make-error@^1.1.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.2.3.tgz#6c4402df732e0977ac6faf754a5074b3d2b1d19d"
+
+make-iterator@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/make-iterator/-/make-iterator-0.3.1.tgz#e1c6a532b546a27f13948a06f82509b33db98112"
+  dependencies:
+    kind-of "^3.1.0"
+
+make-iterator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/make-iterator/-/make-iterator-1.0.0.tgz#57bef5dc85d23923ba23767324d8e8f8f3d9694b"
+  dependencies:
+    kind-of "^3.1.0"
 
 mandrill-api@^1.0.45:
   version "1.0.45"
@@ -2136,6 +2445,10 @@ merge-source-map@^1.0.2:
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.3.tgz#da1415f2722a5119db07b14c4f973410863a2abf"
   dependencies:
     source-map "^0.5.3"
+
+merge@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
 methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
@@ -2194,6 +2507,13 @@ minimist@1.2.0, minimist@^1.2.0:
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+
+mixin-deep@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.2.0.tgz#d02b8c6f8b6d4b8f5982d3fd009c4919851c3fe2"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^0.1.1"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
@@ -2903,6 +3223,19 @@ registry-url@^3.0.3:
   dependencies:
     rc "^1.0.1"
 
+relative@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/relative/-/relative-3.0.2.tgz#0dcd8ec54a5d35a3c15e104503d65375b5a5367f"
+  dependencies:
+    isobject "^2.0.0"
+
+remarkable@^1.6.0, remarkable@^1.6.2:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.1.tgz#aaca4972100b66a642a63a1021ca4bac1be3bff6"
+  dependencies:
+    argparse "~0.1.15"
+    autolinker "~0.15.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz#615ebb96af559552d4bf4057c8436d486ab63cc4"
@@ -3100,6 +3433,12 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
+  dependencies:
+    to-object-path "^0.3.0"
+
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
@@ -3107,6 +3446,10 @@ set-immediate-shim@^1.0.1:
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
 signal-exit@^2.0.0:
   version "2.1.2"
@@ -3314,6 +3657,10 @@ strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+striptags@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-2.2.1.tgz#4c450b708d41b8bf39cf24c49ff234fc6aabfd32"
+
 superagent-proxy@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/superagent-proxy/-/superagent-proxy-1.0.2.tgz#92d3660578f618ed43a82cf8cac799fe2938ba2d"
@@ -3443,6 +3790,16 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
+to-gfm-code-block@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz#25d045a5fae553189e9637b590900da732d8aa82"
+
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
 topo@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
@@ -3495,7 +3852,7 @@ tsconfig@^5.0.2:
     strip-bom "^2.0.0"
     strip-json-comments "^2.0.0"
 
-tslint@^4.5.1:
+tslint@^4.4.2, tslint@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.5.1.tgz#05356871bef23a434906734006fc188336ba824b"
   dependencies:
@@ -3508,6 +3865,23 @@ tslint@^4.5.1:
     resolve "^1.1.7"
     tsutils "^1.1.0"
     update-notifier "^2.0.0"
+
+tsoa@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/tsoa/-/tsoa-1.1.7.tgz#1170f09bf4abce3a6c080e77413a669c16596a80"
+  dependencies:
+    express "^4.14.1"
+    handlebars "^4.0.6"
+    handlebars-helpers "^0.8.0"
+    lodash "^4.17.4"
+    merge "^1.2.0"
+    mkdirp "^0.5.1"
+    moment "^2.17.1"
+    tslint "^4.4.2"
+    typescript "^2.2.1"
+    typescript-formatter "^5.1.0"
+    validator "^7.0.0"
+    yargs "^6.6.0"
 
 tsutils@^1.1.0:
   version "1.4.0"
@@ -3555,6 +3929,13 @@ typemoq@^1.4.1:
     lodash "^4.16.4"
     postinstall-build "^2.1.3"
 
+typescript-formatter@^5.1.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript-formatter/-/typescript-formatter-5.1.3.tgz#97cc9dc397ec20ba96effec24fb8b5676262e62b"
+  dependencies:
+    commandpost "^1.0.0"
+    editorconfig "^0.13.2"
+
 typescript@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
@@ -3583,6 +3964,14 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+underscore.string@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
+
+underscore@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
 unique-string@^1.0.0:
   version "1.0.0"
@@ -3669,6 +4058,10 @@ validator@^6.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-6.3.0.tgz#47ce23ed8d4eaddfa9d4b8ef0071b6cf1078d7c8"
 
+validator@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-7.0.0.tgz#c74deb8063512fac35547938e6f0b1504a282fd2"
+
 vary@^1, vary@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
@@ -3678,6 +4071,10 @@ verror@1.3.6:
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+void-elements@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
 which-module@^1.0.0:
   version "1.0.0"
@@ -3787,7 +4184,7 @@ yargs-parser@^4.0.2, yargs-parser@^4.2.0:
   dependencies:
     camelcase "^3.0.0"
 
-yargs@^6.4.0, yargs@^6.5.0:
+yargs@^6.4.0, yargs@^6.5.0, yargs@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
   dependencies:


### PR DESCRIPTION
super rough take of using TSOA for swagger docs

The big change here is that if we tag up our
controllers like this:

```typescript
@Route("publisher/v1")
export class PublisherController extends Controller {

    private readonly eventCreater: EventCreater;

    constructor(eventCreater: EventCreater) {
        super();
        this.eventCreater = eventCreater;
    }

    @Post("project/{projectId}/event")
    @SuccessResponse("201", "Created")
    @Example<CreateEventResult>({
        id: "abf053dc4a3042459818833276eec717",
        hash:
"5b570bff4628b35262fb401d2f6c9bb38d29e212f6e0e8ea93445b4e5a253d50",
    })
    public async createEvent(
        @Header("Authorization") auth: string,
        @Path("projectId") projectId: string,
        @Body() event: RetracedEvent,
    ): Promise<CreateEventResult> {

        const result: any = await this.eventCreater.createEvent(auth,
projectId, event);

        this.setStatus(result.status);
        return Promise.resolve(result.body);

    }
}
```

Then we'll get free swagger specifications auto-generated.

The biggest thing to note is that these TSOA-style controllers
that are tagged up with decorators dont actually give any routing
or request parsing out of the box, we still neeed to use all the same
custom express middleware we've been using.

To that end, I've refactored a lot of the pre/post request processing
and error handling (mostly around logging) out of
`index.ts#buildRoutes()` and into some helper functions. These are used
to build both the old-style routes with `req => { status: number, body: string }`
and the new style-routes that use a TSOA controller.

The old routes look like:

```typescript
  pulisherCreateViewerDescriptor: {
    path: "/publisher/v1/project/:projectId/viewertoken",
    method: "get",
    handler: createViewerDescriptor,
  },
```

And the new TSOA style routes look like

```typescript
    createEvent: {
      path: "/v1/project/:projectId/event",
      method: "post",
      controller: publisherController,
      controllerMethod: publisherController.createEvent,
      argsFrom: (request: express.Request) =>
[request.get("Authorization"), request.params.projectId, request.body],
    },
```

Two biggest differences being:

- while an old-style route has a `handler: req => { status: number, body: string }`,
  the tsoa routes have a controller and a method that will be `apply`'d
  to handle the request
- Instead of taking `express.Request`, the tsoa route includes a
  `argsFrom: req => any[]` that will be used to create the `arguments`
  array that will be passed to the controller. We lose a little type
  safety here, there may be a better way to encode this stuff that still
  lets us have some sort of type checking while injecting our controller args.




