### PR TITLE
metric paths are different now

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -60,8 +60,8 @@ export function bootstrapFromEnv() {
     const statusPageUrl = process.env.STATUSPAGEIO_URL || "api.statuspage.io";
     const intervalMs = process.env.STATUSPAGEIO_INTERVAL_MILLIS || 30000;
     const metricIds = {
-        "EventCreater.createEvent.mean": "whb4rfgv5fzv",
-        "EventCreater.createEvent.p98": "stkhk01nkb4f",
+        "EventCreater.createEvent.timer.mean": "whb4rfgv5fzv",
+        "EventCreater.createEvent.timer.p98": "stkhk01nkb4f",
         "EventCreater.createEvent.errors.m1_rate": "xgntq7qsk0cl",
     };
 


### PR DESCRIPTION
This has caused us to not get statuspage metrics for a few days. Need to think of a good way to regression test this stuff. Can probably do some sort of alerting in sysdig.