### PR TITLE
NaNNaNNaNNaNNaNNaNNaNNaN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ k8s-pre:
 	mkdir -p build/k8s
 
 k8s-deployment:
-	`yarn bin`/handlebars --tag $(tag)       < deploy/k8s/api-deployment.yml.hbs > build/k8s/api-deployment.yml
+	`yarn bin`/handlebars --tag '"$(tag)"'       < deploy/k8s/api-deployment.yml.hbs > build/k8s/api-deployment.yml
 
 k8s-service:
 	`yarn bin`/handlebars                          < deploy/k8s/api-service.yml.hbs    > build/k8s/api-service.yml


### PR DESCRIPTION
the argument to `handlebars --tag` is fed directly to `JSON.parse()`,
which means that certain tags like "26e7694" get parsed as scientific
notation `number`s instead of `string`s, and handlebars ends up
rendering them as `Infinity` instead of the SHA we wanted. Wheee.