### PR TITLE
Better framework error handling

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -71,7 +71,7 @@ function handleFrameworkError(err: any, reqId: string, res: express.Response) {
   };
   res.status(err.status).set("X-Retraced-RequestId", reqId).json(bodyToSend);
 
-};
+}
 
 function handleUnexpectedError(err: any, reqId: string, res: express.Response) {
   bugsnag.notify(err);

--- a/src/test/router.ts
+++ b/src/test/router.ts
@@ -10,7 +10,7 @@ import { onError } from "../router";
 
 const once = TypeMoq.Times.once;
 
-@suite class SwaggerTest {
+@suite class RouterTest {
     @test public "router.onError()({status: 400, message: 'Authorization is a required header parameter.'})"() {
         const res = TypeMoq.Mock.ofType<express.Response>();
         const reqId = "8675309";


### PR DESCRIPTION
The errors thrown by the tsoa param validator look like

```
InvalidRequestException {
    message: '\'Authorization\' is a required header parameter.',
    status: 400,
    name: 'Invalid Request' }
```

so add a check for `err.message` if `err.err` is not there.

Still default to "An unexpected error occured" if neither
`err.err.message` or `err.message` is present.