### PR TITLE
crud is required, request fields are snake_case

### DIFF
--- a/src/handlers/createEvent.ts
+++ b/src/handlers/createEvent.ts
@@ -55,16 +55,16 @@ export interface TargetRequest {
 
 export interface CreateEventRequest {
   action: string;
+  crud: crud;
   group?: GroupRequest;
   displayTitle?: string;
   created?: number;
   actor?: ActorRequest;
   target?: TargetRequest;
-  crud?: crud;
-  sourceIp?: string;
+  source_ip?: string;
   description?: string;
-  isAnonymous?: boolean;
-  isFailure?: boolean;
+  is_anonymous?: boolean;
+  is_failure?: boolean;
   fields?: Fields;
 }
 

--- a/src/models/event/index.ts
+++ b/src/models/event/index.ts
@@ -27,7 +27,7 @@ export interface RetracedEvent {
   id?: string;
   action: string;
   group?: Group;
-  displayTitle?: string;
+  display_title?: string;
   created?: number;
   actor?: Actor;
   target?: Target;


### PR DESCRIPTION
This only affects our swagger spec, events in database are still snake_cased properly.