### PR TITLE
Fix sigsci tarball to v1.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ruler": "^1.0.0",
     "sanitize-filename": "^1.6.1",
     "search-query-parser": "^1.3.0",
-    "sigsci-module-nodejs": "https://dl.signalsciences.net/sigsci-module-nodejs/sigsci-module-nodejs_latest.tgz",
+    "sigsci-module-nodejs": "https://dl.signalsciences.net/sigsci-module-nodejs/1.4.4/sigsci-module-nodejs-1.4.4.tgz",
     "source-map-support": "^0.4.11",
     "swagger-jsdoc": "^1.9.2",
     "swagger-ui-express": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3482,9 +3482,9 @@ signal-exit@^3.0.0, signal-exit@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-"sigsci-module-nodejs@https://dl.signalsciences.net/sigsci-module-nodejs/sigsci-module-nodejs_latest.tgz":
+"sigsci-module-nodejs@https://dl.signalsciences.net/sigsci-module-nodejs/1.4.4/sigsci-module-nodejs-1.4.4.tgz":
   version "1.4.4"
-  resolved "https://dl.signalsciences.net/sigsci-module-nodejs/sigsci-module-nodejs_latest.tgz#57cfa114a0db12a5b7cb65904506684432891f53"
+  resolved "https://dl.signalsciences.net/sigsci-module-nodejs/1.4.4/sigsci-module-nodejs-1.4.4.tgz#57cfa114a0db12a5b7cb65904506684432891f53"
   dependencies:
     msgpack5rpc "https://registry.npmjs.org/msgpack5rpc/-/msgpack5rpc-1.1.0.tgz"
 


### PR DESCRIPTION
The _latest tarball if non-deterministic and can point to different versions because it's on CloudFront.
If we merge this we'll have to manually update for new releases.
If we leave it at latest the build may keep breaking on releases.