### PR TITLE
GraphQL search populates group.name

### DIFF
--- a/src/handlers/graphql/search.ts
+++ b/src/handlers/graphql/search.ts
@@ -94,8 +94,6 @@ export default async function search(
     totalCount = totalHits;
   }
 
-
-
   return {
     totalCount,
     edges,


### PR DESCRIPTION
This ensure the new group column in the admin site has a name even if the raw event from the client included group.id.