### PR TITLE
static ip

### DIFF
--- a/deploy/k8s/api-ingress.yml.hbs
+++ b/deploy/k8s/api-ingress.yml.hbs
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: api-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "api-ingress"
 spec:
   tls:
     - secretName: api-tls


### PR DESCRIPTION
To match production, Addresses in staging will need to be re-created or re-named

```
gcloud compute addresses list --project retraced-production
NAME                                          REGION  ADDRESS        STATUS
api                                                   35.186.209.208 RESERVED
api-ingress                                           35.186.223.140 IN_USE
k8s-fw-default-app-ingress--2cf4ac698c378c8a          130.211.41.132 IN_USE
kubernetes-logs-ingress                               35.190.16.200 IN_USE
```

```
gcloud compute addresses list --project retraced-staging
NAME                                           REGION  ADDRESS        STATUS
k8s-fw-default-api-ingress--4ca49672df842431           35.190.30.22   IN_USE
k8s-fw-default-api-ingress--a07bcb39e43a787d           35.190.31.110  IN_USE
k8s-fw-default-logs-ingress--4ca49672df842431          35.186.253.196 RESERVED
logs-ingress                                           35.190.27.184  IN_USE

```

We will probably have to coordinate one more DNS change for staging.