### PR TITLE
More descriptive audit events

### DIFF
--- a/src/handlers/createEnterpriseToken.ts
+++ b/src/handlers/createEnterpriseToken.ts
@@ -3,7 +3,6 @@ import getApiToken from "../models/api_token/get";
 import createEitapiToken from "../models/eitapi_token/create";
 import { apiTokenFromAuthHeader } from "../security/helpers";
 import getPgPool from "../persistence/pg";
-import { defaultEventCreater, CreateEventRequest } from "./createEvent";
 
 const pgPool = getPgPool();
 
@@ -23,8 +22,6 @@ export async function createEnterpriseToken(
     projectId: string,
     groupId: string,
     opts: CreateEnterpriseToken,
-    ip: string,
-    route: string,
 ): Promise<EnterpriseToken> {
    const apiTokenId = apiTokenFromAuthHeader(authorization);
    const apiToken: any = await getApiToken(apiTokenId, pgPool.query.bind(pgPool));
@@ -46,25 +43,6 @@ export async function createEnterpriseToken(
       display_name: result.display_name,
       view_log_action: result.view_log_action,
     };
-
-   const thisEvent: CreateEventRequest = {
-        action: "eitapi_token.create",
-        crud: "c",
-        actor: {
-            id: "Publisher API",
-            name: apiToken.name,
-        },
-        group: {
-            id: groupId,
-        },
-        description: route,
-        source_ip: ip,
-    };
-   await defaultEventCreater.saveRawEvent(
-        projectId,
-        apiToken.environment_id,
-        thisEvent,
-    );
 
    return body;
 }

--- a/src/handlers/createViewerDescriptor.ts
+++ b/src/handlers/createViewerDescriptor.ts
@@ -10,13 +10,14 @@ export interface ViewerToken {
 export default async function handlerRaw(req): Promise<RawResponse> {
   const auth = req.get("Authorization");
   const projectId = req.params.projectId;
+  const isAdmin = req.query.is_admin === "true";
   const groupId = req.query.group_id;
   const teamId = req.query.team_id;
-  const isAdmin = req.query.is_admin === "true";
   const targetId = req.query.target_id;
   const viewLogAction = req.query.view_log_action;
+  const actorId = req.query.actor_id;
   const token: ViewerToken =
-      await createViewerDescriptor(auth, projectId, isAdmin, groupId, teamId, targetId, viewLogAction);
+      await createViewerDescriptor(auth, projectId, isAdmin, actorId, groupId, teamId, targetId, viewLogAction);
   return Responses.created(token);
 }
 
@@ -24,6 +25,7 @@ export async function createViewerDescriptor(
   auth: string,
   projectId: string,
   isAdmin: boolean,
+  actorId: string,
   groupId?: string,
   teamId?: string,
   targetId?: string,
@@ -47,6 +49,7 @@ export async function createViewerDescriptor(
     groupId,
     isAdmin,
     targetId,
+    actorId,
     viewLogAction: viewLogAction || "audit.log.view",
   });
 

--- a/src/handlers/createViewerSession.ts
+++ b/src/handlers/createViewerSession.ts
@@ -11,6 +11,7 @@ export default async function handler(req) {
   const desc = await getViewerDescriptor({
     id: req.body.token,
   });
+  desc.ip = req.ip;
 
   const voucher = createViewerDescriptorVoucher(desc);
 

--- a/src/handlers/deleteEnterpriseToken.ts
+++ b/src/handlers/deleteEnterpriseToken.ts
@@ -3,7 +3,6 @@ import getApiToken from "../models/api_token/get";
 import modelsDeleteEnterpriseToken from "../models/eitapi_token/delete";
 import { apiTokenFromAuthHeader } from "../security/helpers";
 import getPgPool from "../persistence/pg";
-import { defaultEventCreater, CreateEventRequest } from "./createEvent";
 
 const pgPool = getPgPool();
 
@@ -12,8 +11,6 @@ export async function deleteEnterpriseToken(
     projectId: string,
     groupId: string,
     eitapiTokenId: string,
-    ip: string,
-    route: string,
 ) {
     const apiTokenId = apiTokenFromAuthHeader(authorization);
     const apiToken: any = await getApiToken(apiTokenId, pgPool.query.bind(pgPool));
@@ -36,26 +33,4 @@ export async function deleteEnterpriseToken(
             err: new Error(`Not Found`),
         };
     }
-
-    const thisEvent: CreateEventRequest = {
-        action: "eitapi_token.delete",
-        crud: "d",
-        actor: {
-            id: "Publisher API",
-            name: apiToken.name,
-        },
-        group: {
-            id: groupId,
-        },
-        target: {
-            id: eitapiTokenId,
-        },
-        description: route,
-        source_ip: ip,
-    };
-    await defaultEventCreater.saveRawEvent(
-        projectId,
-        apiToken.environment_id,
-        thisEvent,
-    );
 }

--- a/src/handlers/enterprise/graphql.ts
+++ b/src/handlers/enterprise/graphql.ts
@@ -16,7 +16,10 @@ export default async function(req) {
   const thisViewEvent: CreateEventRequest = {
     action: eitapiToken.viewLogAction,
     crud: "r",
-    is_anonymous: true,
+    actor: {
+      id: `enterprise:${eitapiToken.id.substring(0, 7)}`,
+      name: eitapiToken.displayName,
+    },
     group: {
       id: eitapiToken.group_id,
     },

--- a/src/handlers/enterprise/pumpActiveSearch.ts
+++ b/src/handlers/enterprise/pumpActiveSearch.ts
@@ -113,7 +113,10 @@ export default async function handler(req) {
   const thisViewEvent: CreateEventRequest = {
     action: eitapiToken.viewLogAction,
     crud: "r",
-    is_anonymous: true,
+    actor: {
+      id: `enterprise:${eitapiToken.id.substring(0, 7)}`,
+      name: eitapiToken.displayName,
+    },
     group: {
       id: eitapiToken.group_id,
     },

--- a/src/handlers/enterprise/searchAdHoc.ts
+++ b/src/handlers/enterprise/searchAdHoc.ts
@@ -31,7 +31,10 @@ export default async function handler(req) {
   const thisViewEvent: CreateEventRequest = {
     action: eitapiToken.viewLogAction,
     crud: "r",
-    is_anonymous: true,
+    actor: {
+      id: `enterprise:${eitapiToken.id.substring(0, 7)}`,
+      name: eitapiToken.displayName,
+    },
     group: {
       id: eitapiToken.group_id,
     },

--- a/src/handlers/getEnterpriseToken.ts
+++ b/src/handlers/getEnterpriseToken.ts
@@ -3,7 +3,6 @@ import getApiToken from "../models/api_token/get";
 import modelsGetEnterpriseToken from "../models/eitapi_token/get";
 import { apiTokenFromAuthHeader } from "../security/helpers";
 import getPgPool from "../persistence/pg";
-import { defaultEventCreater, CreateEventRequest } from "./createEvent";
 import { EnterpriseToken } from "./createEnterpriseToken";
 
 const pgPool = getPgPool();
@@ -13,8 +12,6 @@ export async function getEnterpriseToken(
     projectId: string,
     groupId: string,
     eitapiTokenId: string,
-    ip: string,
-    route: string,
 ): Promise<EnterpriseToken> {
     const apiTokenId = apiTokenFromAuthHeader(authorization);
     const apiToken: any = await getApiToken(apiTokenId, pgPool.query.bind(pgPool));
@@ -34,28 +31,6 @@ export async function getEnterpriseToken(
     if (token.project_id !== apiToken.project_id) {
         throw { status: 401, err: new Error("Unauthorized") };
     }
-
-    const thisEvent: CreateEventRequest = {
-        action: "eitapi_token.get",
-        crud: "r",
-        actor: {
-            id: "Publisher API",
-            name: apiToken.name,
-        },
-        group: {
-            id: groupId,
-        },
-        target: {
-            id: eitapiTokenId,
-        },
-        description: route,
-        source_ip: ip,
-    };
-    await defaultEventCreater.saveRawEvent(
-        projectId,
-        apiToken.environment_id,
-        thisEvent,
-    );
 
     return {
         token: token.id,

--- a/src/handlers/listEnterpriseTokens.ts
+++ b/src/handlers/listEnterpriseTokens.ts
@@ -4,7 +4,6 @@ import { apiTokenFromAuthHeader } from "../security/helpers";
 import modelsListEnterpriseTokens from "../models/eitapi_token/list";
 import { EnterpriseToken } from "./createEnterpriseToken";
 import getPgPool from "../persistence/pg";
-import { defaultEventCreater, CreateEventRequest } from "./createEvent";
 
 const pgPool = getPgPool();
 
@@ -12,8 +11,6 @@ export async function listEnterpriseTokens(
   authorization: string,
   projectId: string,
   groupId: string,
-  ip: string,
-  route: string,
 ): Promise<EnterpriseToken[]> {
   const apiTokenId = apiTokenFromAuthHeader(authorization);
   const apiToken: any = await getApiToken(apiTokenId, pgPool.query.bind(pgPool));
@@ -34,25 +31,6 @@ export async function listEnterpriseTokens(
         display_name,
       };
     });
-
-  const thisEvent: CreateEventRequest = {
-    action: "eitapi_tokens.list",
-    crud: "r",
-    actor: {
-      id: "Publisher API",
-      name: apiToken.name,
-    },
-    group: {
-      id: groupId,
-    },
-    description: route,
-    source_ip: ip,
-  };
-  await defaultEventCreater.saveRawEvent(
-    projectId,
-    apiToken.environment_id,
-    thisEvent,
-  );
 
   return tokens;
 }

--- a/src/handlers/updateEnterpriseToken.ts
+++ b/src/handlers/updateEnterpriseToken.ts
@@ -3,7 +3,6 @@ import getApiToken from "../models/api_token/get";
 import modelsUpdateEnterpriseToken from "../models/eitapi_token/update";
 import { apiTokenFromAuthHeader } from "../security/helpers";
 import getPgPool from "../persistence/pg";
-import { defaultEventCreater, CreateEventRequest } from "./createEvent";
 import { EnterpriseToken } from "./createEnterpriseToken";
 
 const pgPool = getPgPool();
@@ -15,8 +14,6 @@ export async function updateEnterpriseToken(
     eitapiTokenId: string,
     displayName: string,
     viewLogAction: string | undefined,
-    ip: string,
-    route: string,
 ): Promise<EnterpriseToken> {
     const apiTokenId = apiTokenFromAuthHeader(authorization);
     const apiToken: any = await getApiToken(apiTokenId, pgPool.query.bind(pgPool));
@@ -41,34 +38,6 @@ export async function updateEnterpriseToken(
             err: new Error(`Not Found`),
         };
     }
-
-    const thisEvent: CreateEventRequest = {
-        action: "eitapi_token.update",
-        crud: "u",
-        actor: {
-            id: "Publisher API",
-            name: apiToken.name,
-        },
-        group: {
-            id: groupId,
-        },
-        target: {
-            id: eitapiTokenId,
-        },
-        description: route,
-        source_ip: ip,
-        fields: {
-            displayName,
-        },
-    };
-    if (viewLogAction) {
-        thisEvent.fields!.viewLogAction = viewLogAction;
-    }
-    await defaultEventCreater.saveRawEvent(
-        projectId,
-        apiToken.environment_id,
-        thisEvent,
-    );
 
     return {
         token: updated.id,

--- a/src/handlers/viewer/createEitapiToken.ts
+++ b/src/handlers/viewer/createEitapiToken.ts
@@ -16,13 +16,13 @@ export default async function(req) {
     action: "eitapi_token.create",
     crud: "c",
     actor: {
-      id: `viewer:${claims.id}`,
+      id: claims.actorId,
     },
     group: {
       id: claims.groupId,
     },
     description: `${req.method} ${req.originalUrl}`,
-    source_ip: req.ip,
+    source_ip: claims.ip,
   };
   await defaultEventCreater.saveRawEvent(
     claims.projectId,

--- a/src/handlers/viewer/deleteEitapiToken.ts
+++ b/src/handlers/viewer/deleteEitapiToken.ts
@@ -17,7 +17,7 @@ export default async function(req) {
     action: "eitapi_token.delete",
     crud: "d",
     actor: {
-      id: `viewer:${claims.id}`,
+      id: claims.actorId,
     },
     group: {
       id: claims.groupId,
@@ -26,7 +26,7 @@ export default async function(req) {
       id: req.params.tokenId,
     },
     description: `${req.method} ${req.originalUrl}`,
-    source_ip: req.ip,
+    source_ip: claims.ip,
   };
   await defaultEventCreater.saveRawEvent(
     claims.projectId,

--- a/src/handlers/viewer/graphql.ts
+++ b/src/handlers/viewer/graphql.ts
@@ -10,12 +10,14 @@ export default async function(req) {
   const thisViewEvent: CreateEventRequest = {
     action: claims.viewLogAction,
     crud: "r",
-    is_anonymous: true,
+    actor: {
+      id: claims.actorId,
+    },
     group: {
       id: claims.groupId,
     },
     description: `${req.method} ${req.originalUrl}`,
-    source_ip: req.ip,
+    source_ip: claims.ip,
   };
 
   let targetId;

--- a/src/handlers/viewer/listEitapiTokens.ts
+++ b/src/handlers/viewer/listEitapiTokens.ts
@@ -14,13 +14,13 @@ export default async function(req) {
     action: "eitapi_tokens.list",
     crud: "r",
     actor: {
-      id: `viewer:${claims.id}`,
+      id: claims.actorId,
     },
     group: {
       id: claims.groupId,
     },
     description: `${req.method} ${req.originalUrl}`,
-    source_ip: req.ip,
+    source_ip: claims.ip,
   };
   await defaultEventCreater.saveRawEvent(
     claims.projectId,

--- a/src/handlers/viewer/searchEvents.ts
+++ b/src/handlers/viewer/searchEvents.ts
@@ -29,12 +29,14 @@ export default async function(req) {
   const thisViewEvent: CreateEventRequest = {
     action: claims.viewLogAction,
     crud: "r",
-    is_anonymous: true,
+    actor: {
+      id: claims.actorId,
+    },
     group: {
       id: claims.groupId,
     },
     description: `${req.method} ${req.originalUrl}`,
-    source_ip: req.ip,
+    source_ip: claims.ip,
   };
 
   const reqOpts = req.body.query;

--- a/src/handlers/viewer/updateEitapiToken.ts
+++ b/src/handlers/viewer/updateEitapiToken.ts
@@ -19,7 +19,7 @@ export default async function(req) {
     action: "eitapi_token.update",
     crud: "u",
     actor: {
-      id: `viewer:${claims.id}`,
+      id: claims.actorId,
     },
     group: {
       id: claims.groupId,
@@ -28,7 +28,7 @@ export default async function(req) {
       id: req.params.tokenId,
     },
     description: `${req.method} ${req.originalUrl}`,
-    source_ip: req.ip,
+    source_ip: claims.ip,
     fields: {
       displayName: req.body.displayName,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,9 @@ if (!process.env["SIGSCI_RPC_ADDRESS"]) {
 }
 
 app.set("etag", false); // we're doing our own etag thing I guess
+// The nearest ip address in the X-Forwarded-For header not in a private
+// subnet will be used as req.ip.
+app.set("trust proxy", "uniquelocal");
 
 app.use(bugsnag.requestHandler);
 app.use(bodyParser.json());

--- a/src/models/viewer_descriptor/create.ts
+++ b/src/models/viewer_descriptor/create.ts
@@ -10,6 +10,7 @@ export interface Options {
   groupId: string;
   isAdmin: boolean;
   viewLogAction: string;
+  actorId: string;
   targetId?: string;
 }
 
@@ -21,6 +22,7 @@ export default async function createViewerDescriptor(opts: Options): Promise<Vie
     groupId: opts.groupId,
     isAdmin: opts.isAdmin,
     viewLogAction: opts.viewLogAction,
+    actorId: opts.actorId,
     created: moment().valueOf(),
     scope: "",
   };

--- a/src/models/viewer_descriptor/def.ts
+++ b/src/models/viewer_descriptor/def.ts
@@ -4,9 +4,11 @@ interface ViewerDescriptor {
   environmentId: string;
   groupId: string;
   isAdmin: boolean;
-  viewLogAction: string;
   created: number;
   scope: string;
+  viewLogAction: string;
+  actorId: string;
+  ip?: string;
 }
 
 export default ViewerDescriptor;


### PR DESCRIPTION
I don't like using the enterprise and viewer tokens as actor id. The enterprise token id is a credential. I can't think of an alternative.

The display_name parameter for createViewerDescriptor is a breaking change to the Publisher API.