### PR TITLE
this is supposed to be a date

### DIFF
--- a/src/handlers/createEvent.ts
+++ b/src/handlers/createEvent.ts
@@ -80,8 +80,8 @@ export interface CreateEventRequest {
    *  This field is deprecated in favor of [Display Templates](https://preview.retraced.io/documentation/advanced-retraced/display-templates/)
    */
   displayTitle?: string;
-  /** millis since epoch representing when this event occurent. `created` will be tracked in addtion to `received` */
-  created?: number;
+  /** ISO8601 date string representing when this event occurent. `created` will be tracked in addtion to `received` */
+  created?: Date;
   actor?: RequestActor;
   target?: RequestTarget;
   /** The source IP address from which the event was initiated */


### PR DESCRIPTION
Replicated has been sending as a string, and the golang client sends as a string. Will update the JS client to enforce the ISO8601 string as well