### PR TITLE
create search and write aliases

### DIFF
--- a/src/models/environment/create.ts
+++ b/src/models/environment/create.ts
@@ -1,6 +1,5 @@
 import "source-map-support/register";
 import * as uuid from "uuid";
-import * as moment from "moment";
 
 import getPgPool from "../../persistence/pg";
 import getEs from "../../persistence/elasticsearch";
@@ -22,7 +21,7 @@ export default async function createEnvironment(opts: Opts) {
 
   // Create the ES index
   const searchAlias = `retraced.${environment.project_id}.${environment.id}`;
-  const writeAlias = `retraced.${environment.project_id}.${environment.id}.${moment.utc().format("YYYYMMDD")}`;
+  const writeAlias = `retraced.${environment.project_id}.${environment.id}.current`;
   const newIndex = `retraced.api.${uuid.v4().replace(/-/g, "")}`;
   const aliases = {};
   aliases[searchAlias] = {};


### PR DESCRIPTION
We want to be writing to a new index every day, but still searching across all indices. See related processor PR -- processor will write to the alias retraced.projectId.envId.YYYYMMDD, so when we create the index retraced.api.UUID, add an additional alias for the processor to write to.