### PR TITLE
GraphQL in Publisher Contoller

### DIFF
--- a/src/controllers/PublisherController.ts
+++ b/src/controllers/PublisherController.ts
@@ -6,6 +6,8 @@ import { deleteEnterpriseToken } from "../handlers/deleteEnterpriseToken";
 import { listEnterpriseTokens } from "../handlers/listEnterpriseTokens";
 import { updateEnterpriseToken } from "../handlers/updateEnterpriseToken";
 import { getEnterpriseToken } from "../handlers/getEnterpriseToken";
+import { graphQL } from "../handlers/graphql";
+import { GraphQLRequest, GraphQLResponse } from "../handlers/graphql/index";
 
 @Route("publisher/v1")
 export class PublisherController extends Controller {
@@ -258,5 +260,32 @@ export class PublisherController extends Controller {
         );
 
         this.setStatus(204);
+    }
+
+    /**
+     * Query events with GraphQL
+     *
+     * https://preview.staging.retraced.io/documentation/apis/graphql/
+     *
+     * @param auth            auth header of the form Token token=...
+     * @param projectId       the project id
+     * @param graphQLRequest  graphQL query, variables, and operationName
+     */
+    @Post("project/{projectId}/graphql")
+    @SuccessResponse("200", "OK")
+    public async graphqlPost(
+        @Header("Authorization") auth: string,
+        @Path("projectId") projectId: string,
+        @Body() graphQLRequest: GraphQLRequest,
+    ): Promise<GraphQLResponse> {
+        const result = await graphQL(
+            auth,
+            projectId,
+            graphQLRequest,
+        );
+
+        this.setStatus(result.errors ? 400 : 200);
+
+        return result;
     }
 }

--- a/src/handlers/graphql.ts
+++ b/src/handlers/graphql.ts
@@ -1,15 +1,51 @@
 import "source-map-support/register";
+import { graphql } from "graphql";
 
+import getPgPool from "../persistence/pg";
 import { apiTokenFromAuthHeader } from "../security/helpers";
 import getApiToken from "../models/api_token/get";
+import { Scope } from "../security/scope";
+import schema from "./graphql/schema";
 import handler from "./graphql/handler";
+import { GraphQLRequest, GraphQLResponse } from "./graphql/index";
 
-export default async function graphql(req) {
-  const apiTokenId = apiTokenFromAuthHeader(req.get("Authorization"));
-  const apiToken: any = await getApiToken(apiTokenId);
+const pgPool = getPgPool();
 
-  return await handler(req, {
-    projectId: apiToken.project_id,
-    environmentId: apiToken.environment_id,
-  });
+export default async function(req) {
+    const apiTokenId = apiTokenFromAuthHeader(req.get("Authorization"));
+    const apiToken: any = await getApiToken(apiTokenId);
+
+    return await handler(req, {
+        projectId: apiToken.project_id,
+        environmentId: apiToken.environment_id,
+    });
+}
+
+export async function graphQL(
+    authorization: string,
+    projectId: string,
+    graphQLReq: GraphQLRequest,
+): Promise<GraphQLResponse> {
+    const apiTokenId = apiTokenFromAuthHeader(authorization);
+    const apiToken: any = await getApiToken(apiTokenId, pgPool.query.bind(pgPool));
+    const validAccess = apiToken && apiToken.project_id === projectId;
+
+    if (!validAccess) {
+        throw { status: 401, err: new Error("Unauthorized") };
+    }
+
+    const context: Scope = {
+        projectId: apiToken.project_id,
+        environmentId: apiToken.environment_id,
+    };
+
+    // http://graphql.org/graphql-js/graphql/#graphql
+    return await graphql(
+        schema,
+        graphQLReq.query,
+        null,
+        context,
+        graphQLReq.variables,
+        graphQLReq.operationName,
+    );
 }

--- a/src/handlers/graphql/index.ts
+++ b/src/handlers/graphql/index.ts
@@ -1,0 +1,101 @@
+export interface FieldItem {
+  key: string;
+  value: string;
+}
+
+export interface EventNodeGroup {
+  id?: string;
+  name?: string;
+}
+
+export interface EventNodeActor {
+  id?: string;
+  name?: string;
+  href?: string;
+  fields?: FieldItem[];
+}
+
+export interface EventNodeTarget {
+  id?: string;
+  name?: string;
+  href?: string;
+  type?: string;
+  fields?: FieldItem[];
+}
+
+export interface EventNodeDisplay {
+  markdown?: string;
+}
+
+export interface EventNode {
+  id?: string;
+  action?: string;
+  crud?: "c" | "r" | "u" | "d";
+  description?: string;
+  group?: EventNodeGroup;
+  actor?: EventNodeActor;
+  target?: EventNodeTarget;
+  display?: EventNodeDisplay;
+  is_failure?: boolean;
+  is_anonymous?: boolean;
+  source_ip?: string;
+  country?: string;
+  loc_subdiv1?: string;
+  loc_subdiv2?: string;
+  received?: string;
+  created?: string;
+  fields?: FieldItem[];
+  canonical_time?: string;
+  component?: string;
+  version?: string;
+  raw?: string;
+}
+
+export interface EventEdge {
+  node?: EventNode;
+  cursor?: string;
+}
+
+export interface PageInfo {
+  hasNextPage?: boolean;
+  hasPreviousPage?: boolean;
+}
+
+export interface EventsConnection {
+  edges?: EventEdge[];
+  pageInfo?: PageInfo;
+  totalCount?: number;
+}
+
+export interface GraphQLSearchVars {
+  query?: string;
+  last?: number;
+  before?: string;
+}
+
+export interface GraphQLSearchData {
+  search: EventsConnection;
+}
+
+export interface DocLocation {
+  line: number;
+  column: number;
+}
+
+export interface GraphQLError {
+  message: string;
+  locations?: DocLocation[];
+  // path is actually (number|string)[];
+  path?: string[];
+}
+
+export interface GraphQLResponse {
+  data?: GraphQLSearchData;
+  errors?: GraphQLError[];
+}
+
+export interface GraphQLRequest {
+    query: string;
+    variables?: GraphQLSearchVars;
+    operationName?: string;
+}

--- a/src/handlers/graphql/schema.ts
+++ b/src/handlers/graphql/schema.ts
@@ -227,6 +227,16 @@ const eventType = new GraphQLObjectType({
       description: "The granular area of the country the actor was in when the action was performed (City).",
     },
 
+    component: {
+      type: GraphQLString,
+      description: "An identifier for the vendor app component that sent the event.",
+    },
+
+    version: {
+      type: GraphQLString,
+      description: "An identifier for the version of the vendor app that sent the event, usually a git SHA",
+    },
+
     // GraphQL does not have a map type. Fields is a list of key-value objects.
     fields: {
       description: "The set of fields associated with this event.",


### PR DESCRIPTION
This is for the friendly graphQL method on the SDKs.

Add typescript types for TSOA.
Add component and version fields to GraphQL schema.