### PR TITLE
Move api token operations to TSOA and audit

### DIFF
--- a/src/handlers/admin/createApiToken.ts
+++ b/src/handlers/admin/createApiToken.ts
@@ -1,8 +1,10 @@
-import { checkAdminAccess } from "../../security/helpers";
+import { checkAdminAccess, checkAdminAccessUnwrapped } from "../../security/helpers";
+import { ApiTokenValues } from "../../models/api_token";
 import createApiToken from "../../models/api_token/create";
 import listApiTokens from "../../models/api_token/list";
 
-export default async function (req) {
+// for /v1/project/:projectId/token
+export async function deprecated(req) {
   await checkAdminAccess(req);
 
   await createApiToken(
@@ -22,4 +24,22 @@ export default async function (req) {
     status: 201,
     body: JSON.stringify({ apiTokens }),
   };
+}
+
+export default async function createAPIToken(
+    authorization: string,
+    projectId: string,
+    environmentId: string,
+    token: string,
+    values: ApiTokenValues,
+) {
+    await checkAdminAccessUnwrapped(authorization, projectId);
+
+    return await createApiToken(
+        projectId,
+        environmentId,
+        values,
+        undefined,
+        token,
+    );
 }

--- a/src/handlers/admin/deleteApiToken.ts
+++ b/src/handlers/admin/deleteApiToken.ts
@@ -1,15 +1,28 @@
-import { checkAdminAccess } from "../../security/helpers";
+import { checkAdminAccess, checkAdminAccessUnwrapped } from "../../security/helpers";
 import deleteApiToken from "../../models/api_token/delete";
 
-export default async function(req) {
-  await checkAdminAccess(req);
+export async function deprecated(req) {
+    await checkAdminAccess(req);
 
-  await deleteApiToken({
-    projectId: req.params.projectId,
-    tokenId: req.params.tokenId,
-  });
+    await deleteApiToken({
+        projectId: req.params.projectId,
+        tokenId: req.params.tokenId,
+    });
 
-  return {
-    status: 204,
-  };
+    return {
+        status: 204,
+    };
+}
+
+export default async function(
+    auth: string,
+    projectId: string,
+    tokenId: string,
+): Promise<void> {
+    await checkAdminAccessUnwrapped(auth, projectId);
+
+    await deleteApiToken({
+        projectId,
+        tokenId,
+    });
 }

--- a/src/handlers/admin/updateApiToken.ts
+++ b/src/handlers/admin/updateApiToken.ts
@@ -1,8 +1,7 @@
-import * as _ from "lodash";
 
 import { checkAdminAccessUnwrapped } from "../../security/helpers";
 import updateApiToken from "../../models/api_token/update";
-import { ApiTokenValues } from "../../models/api_token";
+import { ApiToken, ApiTokenValues } from "../../models/api_token";
 
 // TODO(zhaytee): Do we really need all of these pass-through handler functions?
 // This logic can probably be executed directly from within the controller.
@@ -11,11 +10,9 @@ export default async function handle(
   authorization: string,
   projectId: string,
   apiToken: string,
-  requestBody: Partial<ApiTokenValues>,
-) {
+  values: Partial<ApiTokenValues>,
+): Promise<ApiToken> {
   await checkAdminAccessUnwrapped(authorization, projectId);
 
-  if (!_.isEmpty(requestBody)) {
-    await updateApiToken(apiToken, requestBody);
-  }
+  return await updateApiToken(apiToken, values);
 }

--- a/src/models/api_token/index.ts
+++ b/src/models/api_token/index.ts
@@ -12,6 +12,15 @@ export interface ApiToken extends ApiTokenValues {
   projectId: string;
 }
 
+export interface ApiTokenResponse {
+  token: string;
+  project_id: string;
+  environment_id: string;
+  disabled: boolean;
+  name: string;
+  created: string;
+}
+
 export function apiTokenFromRow(row: any): ApiToken {
   return {
     token: row.token,

--- a/src/models/api_token/update.ts
+++ b/src/models/api_token/update.ts
@@ -9,6 +9,9 @@ export default async function update(tokenId: string, fields: Partial<ApiTokenVa
   if (!extant) {
     throw new Error(`Can't find api token to be updated (token='${tokenId}')`);
   }
+  if (fields.disabled === undefined && fields.name === undefined) {
+    return extant;
+  }
 
   let sets: string[] = [];
   const v: any[] = [tokenId];

--- a/src/models/project/create.js
+++ b/src/models/project/create.js
@@ -84,10 +84,12 @@ export default function createProject(opts) {
           for (const t of newApiTokens) {
             project.tokens.push(t);
           }
-          return addUserToProject({
-            projectId: project.id,
-            userId: opts.user_id,
-          });
+          if (opts.user_id) {
+            return addUserToProject({
+              projectId: project.id,
+              userId: opts.user_id,
+            });
+          }
         })
         .then(() => {
           resolve(project);

--- a/src/router.ts
+++ b/src/router.ts
@@ -61,9 +61,9 @@ export const onSuccess = (res: express.Response, reqId: string, statusCodeGetter
     }
     respObj.send(body);
   } else {
-    // Generic response. Shouldn't happen in most cases, but...
-    console.log(chalk.cyan(`[${reqId}] => 200`));
-    res.status(200).set("X-Retraced-RequestId", reqId).json(result);
+    const statusToSend = (statusCodeGetter && statusCodeGetter()) || 200;
+    console.log(chalk.cyan(`[${reqId}] => ${statusToSend}`));
+    res.status(statusToSend).set("X-Retraced-RequestId", reqId).json(result);
   }
 };
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,11 +8,11 @@ import graphQL from "./handlers/graphql";
 // admin
 import adminGraphQL from "./handlers/admin/graphql";
 import cancelEmailReport from "./handlers/admin/cancelEmailReport";
-import createApiToken from "./handlers/admin/createApiToken";
+import { deprecated as createApiToken } from "./handlers/admin/createApiToken";
 import createEnvironment from "./handlers/admin/createEnvironment";
 import createInvite from "./handlers/admin/createInvite";
 import createProject from "./handlers/admin/createProject";
-import deleteApiToken from "./handlers/admin/deleteApiToken";
+import { deprecated as deleteApiToken } from "./handlers/admin/deleteApiToken";
 import deleteTeamMember from "./handlers/admin/deleteTeamMember";
 import listTeamMembers from "./handlers/admin/listTeamMembers";
 import deleteInvite from "./handlers/admin/deleteInvite";
@@ -83,11 +83,6 @@ export default {
     method: "get",
     handler: cancelEmailReport,
   },
-  adminCreateApiToken: {
-    path: "/admin/v1/project/:projectId/token",
-    method: "post",
-    handler: createApiToken,
-  },
   adminCreateEnvironment: {
     path: "/admin/v1/project/:projectId/environment",
     method: "post",
@@ -102,11 +97,6 @@ export default {
     path: "/admin/v1/project",
     method: "post",
     handler: createProject,
-  },
-  adminDeleteApiToken: {
-    path: "/admin/v1/project/:projectId/token/:tokenId",
-    method: "delete",
-    handler: deleteApiToken,
   },
   adminDeleteTeamMember: {
     path: "/admin/v1/project/:projectId/team/member/:userId",


### PR DESCRIPTION
Fix 204 response in onsuccess handler.
Create project user section is optional because headless project may not
have a user.
Update API token returns the resource.
Update uses path item token in url to match other endpoints.