### PR TITLE
fix: [ch652] Send ES scroll_id in Body instead of Querystring

### DIFF
--- a/src/handlers/viewer/renderSavedExport.ts
+++ b/src/handlers/viewer/renderSavedExport.ts
@@ -5,7 +5,12 @@ export default async function(req) {
   // Note that this call needs the JWT passed in as a query string param.
   // This is because we will be calling this from window.open() in a browser,
   // and there's no way to set headers in that circumstance.
+  //
+  // TODO
+  // Leaking the JWT is bad though, ideally this should use a single-use
+  // nonce instead
   const claims = await validateViewerDescriptorVoucher(req.query.jwt);
+
   const format = req.query.format || "csv";
   let contentType;
   switch (format) {

--- a/src/models/event/search.ts
+++ b/src/models/event/search.ts
@@ -230,7 +230,10 @@ export default async function(opts: Options): Promise<Result> {
         results.events!.push(hit["_source"]);
       }
       while (true) {
-        const resp = await es.scroll(scrollParams);
+        const resp = await es.scroll({
+          scroll: scrollParams.scroll,
+          body: scrollParams.scroll_id,
+        });
         if (resp.hits.hits.length === 0) {
           break;
         }


### PR DESCRIPTION
It gets pretty long and ES netty has something like a 4k limit on uri length

https://github.com/elastic/elasticsearch-js/issues/113