### PR TITLE
[ch142] Audit admin create and delete environment actions

### DIFF
--- a/src/models/environment/index.ts
+++ b/src/models/environment/index.ts
@@ -2,11 +2,17 @@ import { DeletionRequestHydrated } from "../deletion_request";
 
 export interface EnvironmentValues {
   name: string;
-  projectId: string;
 }
 
 export interface Environment extends EnvironmentValues {
+  projectId: string;
   id: string;
+}
+
+export interface EnvironmentResponse {
+  id: string;
+  project_id: string;
+  name: string;
 }
 
 export interface EnvironmentHydrated extends Environment {
@@ -22,6 +28,14 @@ export function environmentFromRow(row: any): Environment {
 }
 
 export function rowFromEnvironment(env: Environment): any {
+  return {
+    id: env.id,
+    name: env.name,
+    project_id: env.projectId,
+  };
+}
+
+export function responseFromEnvironment(env: Environment): EnvironmentResponse {
   return {
     id: env.id,
     name: env.name,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -9,7 +9,7 @@ import graphQL from "./handlers/graphql";
 import adminGraphQL from "./handlers/admin/graphql";
 import cancelEmailReport from "./handlers/admin/cancelEmailReport";
 import { deprecated as createApiToken } from "./handlers/admin/createApiToken";
-import createEnvironment from "./handlers/admin/createEnvironment";
+import { deprecated as createEnvironment } from "./handlers/admin/createEnvironment";
 import createInvite from "./handlers/admin/createInvite";
 import createProject from "./handlers/admin/createProject";
 import { deprecated as deleteApiToken } from "./handlers/admin/deleteApiToken";


### PR DESCRIPTION
For delete auditing, the handler has several validations to check before
it does the deletion. The normal pattern of auditing in the
controller before passing off to the handler would be inaccurate.
Instead pass the audit function to run as a pre-delete hook after
validations succeed.