### PR TITLE
[ch1089] log client uuids

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -124,7 +124,15 @@ export const preRequest = (req: express.Request, reqId: string) => {
 };
 
 export const requestId = (req: express.Request, handlerName: string) => {
-  return `${handlerName}:${uuid.v4().replace("-", "").substring(0, 8)}`;
+  const id = `${handlerName}:${uuid.v4().replace("-", "").substring(0, 8)}`;
+
+  const clientID = req.headers["x-request-uuid"];
+
+  if (clientID) {
+    return `${id}.${clientID.substring(0, 8)}`;
+  }
+
+  return id;
 };
 
 export const wrapRoute = (route, handlerName) =>


### PR DESCRIPTION
If client specifies X-Request-Uuid header like 68ba7ca8-1287... then API
logs prefix will be:

`[PublisherAPI.createEvent:a91b79e8.68ba7ca8]`

If not set, the prefix would be `[PublisherAPI.createEvent:a91b79e8]`