### PR TITLE
backup writes after timeout in createEvent [ch1901]

### DIFF
--- a/src/persistence/pg.ts
+++ b/src/persistence/pg.ts
@@ -12,7 +12,7 @@ export default function getPgPool(): pg.Pool {
       host: process.env.POSTGRES_HOST,
       port: process.env.POSTGRES_PORT,
       max: process.env.POSTGRES_POOL_SIZE || 10,
-      idleTimeoutMillis: 30000, // how long a client is allowed to remain idle before being closed
+      idleTimeoutMillis: Number(process.env.PUBLISHER_CREATE_EVENT_TIMEOUT) || 2000, // how long a client is allowed to remain idle before being closed
     });
   }
 


### PR DESCRIPTION
The createEvent handler (non-bulk) writes to the backlog table. If approaching the new `PUBLISHER_CREATE_EVENT_TIMEOUT`, publish the event to the `unsaved_events` queue. The handler returns a 201 as soon as the first write succeeds, whether to Postgres or NSQ. The createEvent handler no longer writes to the `ingest_task` table.

My first implementation kept the `ingest_task` write with a backup write to the backlog at half of the timeout, then a third backup to NSQ just before the timeout. I tested with the seed utility with 1000 events at a time and found that the extra write to Postgres caused the handler to fall back to the queue for ~900 events with a 1000ms timeout.

Using only the legacy write to 'ingest_task' with a backup to NSQ, with 1000 events, around 500-700 ended up requiring the queue.

Using only the `backlog` write with a backup to NSQ, seeding 1000 events would require only 0 to 300 events use the queue. In most tests all 1000 were written to the `backlog` table within 800ms and the queue was not used.

The metrics showed that the inserts were faster on the backlog table, which was expected because it has no indexes and no updates. The majority of the time spent in createEvent is waiting for a client connection in the pool. Dropping the idle timeout from 30s to 2s default cut down 50% of the mean waiting to connect time.