### PR TITLE
node 8.7 comes with yarn 1.2.0

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7.8
+FROM node:8.7
 
 EXPOSE 3000
 


### PR DESCRIPTION
Yarn 1.2.0 does not require a separate installation of node-gyp