### PR TITLE
Fix connection pool contention

### DIFF
--- a/src/_processor/models/action/upsert.ts
+++ b/src/_processor/models/action/upsert.ts
@@ -1,65 +1,56 @@
 import "source-map-support/register";
 import * as uuid from "uuid";
 import * as moment from "moment";
+import { PoolClient } from "pg";
 
-import getPgPool from "../../persistence/pg";
+export default async function(opts, pg: PoolClient) {
+  const action = {
+    id: uuid.v4().replace(/-/g, ""),
+    project_id: opts.projectId,
+    environment_id: opts.environmentId,
+    created: moment().valueOf(),
+    first_active: moment().valueOf(),
+    last_active: moment().valueOf(),
+    event_count: 1,
+    action: opts.action,
+  };
 
-const pgPool = getPgPool();
-
-export default async function(opts) {
-  const pg = await pgPool.connect();
-  try {
-    const action = {
-      id: uuid.v4().replace(/-/g, ""),
-      project_id: opts.projectId,
-      environment_id: opts.environmentId,
-      created: moment().valueOf(),
-      first_active: moment().valueOf(),
-      last_active: moment().valueOf(),
-      event_count: 1,
-      action: opts.action,
-    };
-
-    let onConflict = `do update set
-        event_count = (select event_count from action where environment_id = $3 and action = $6) + 1,
-        last_active = to_timestamp($7::double precision / 1000)`;
-    if (opts.updateOnConflict === false) {
-      onConflict = "do nothing";
-    }
-
-    const q = `insert into action (
-        id, created, environment_id, event_count, first_active, action, last_active, project_id
-      ) values (
-        $1, to_timestamp($2::double precision / 1000), $3, $4, to_timestamp($5::double precision / 1000), $6, to_timestamp($7::double precision / 1000), $8
-      ) on conflict (environment_id, action) ${onConflict}`;
-
-    const v = [
-      action.id,
-      action.created,
-      action.environment_id,
-      action.event_count,
-      action.first_active,
-      action.action,
-      action.last_active,
-      action.project_id,
-    ];
-
-    await pg.query(q, v);
-
-    const fields = `id, environment_id, event_count, action, project_id, display_template,
-      extract(epoch from created) * 1000 as created,
-      extract(epoch from first_active) * 1000 as first_active,
-      extract(epoch from last_active) * 1000 as last_active`;
-    const qq = `select ${fields} from action where environment_id = $1 and action = $2`;
-    const vv = [opts.environmentId, opts.action];
-    const result = await pg.query(qq, vv);
-    if (result.rowCount > 0) {
-      return result.rows[0];
-    }
-
-    return null;
-
-  } finally {
-    pg.release();
+  let onConflict = `do update set
+    event_count = (select event_count from action where environment_id = $3 and action = $6) + 1,
+    last_active = to_timestamp($7::double precision / 1000)`;
+  if (opts.updateOnConflict === false) {
+    onConflict = "do nothing";
   }
+
+  const q = `insert into action (
+    id, created, environment_id, event_count, first_active, action, last_active, project_id
+  ) values (
+  $1, to_timestamp($2::double precision / 1000), $3, $4, to_timestamp($5::double precision / 1000), $6, to_timestamp($7::double precision / 1000), $8
+  ) on conflict (environment_id, action) ${onConflict}`;
+
+  const v = [
+    action.id,
+    action.created,
+    action.environment_id,
+    action.event_count,
+    action.first_active,
+    action.action,
+    action.last_active,
+    action.project_id,
+  ];
+
+  await pg.query(q, v);
+
+  const fields = `id, environment_id, event_count, action, project_id, display_template,
+  extract(epoch from created) * 1000 as created,
+  extract(epoch from first_active) * 1000 as first_active,
+  extract(epoch from last_active) * 1000 as last_active`;
+  const qq = `select ${fields} from action where environment_id = $1 and action = $2`;
+  const vv = [opts.environmentId, opts.action];
+  const result = await pg.query(qq, vv);
+  if (result.rowCount > 0) {
+    return result.rows[0];
+  }
+
+  return null;
 }

--- a/src/_processor/models/actor/upsert.ts
+++ b/src/_processor/models/actor/upsert.ts
@@ -1,75 +1,66 @@
 import "source-map-support/register";
 import * as uuid from "uuid";
 import * as moment from "moment";
+import { PoolClient } from "pg";
 
-import getPgPool from "../../persistence/pg";
+export default async function(opts, pg: PoolClient) {
+  const actor = {
+    id: uuid.v4().replace(/-/g, ""),
+    foreign_id: opts.actor.id,
+    project_id: opts.projectId,
+    environment_id: opts.environmentId,
+    name: opts.actor.name,
+    url: opts.actor.href,
+    fields: JSON.stringify(opts.actor.fields),
+    created: moment().valueOf(),
+    event_count: 1,
+    first_active: moment().valueOf(),
+    last_active: moment().valueOf(),
+    retraced_object_type: "actor",
+  };
 
-const pgPool = getPgPool();
-
-export default async function(opts) {
-  const pg = await pgPool.connect();
-  try {
-    const actor = {
-      id: uuid.v4().replace(/-/g, ""),
-      foreign_id: opts.actor.id,
-      project_id: opts.projectId,
-      environment_id: opts.environmentId,
-      name: opts.actor.name,
-      url: opts.actor.href,
-      fields: JSON.stringify(opts.actor.fields),
-      created: moment().valueOf(),
-      event_count: 1,
-      first_active: moment().valueOf(),
-      last_active: moment().valueOf(),
-      retraced_object_type: "actor",
-    };
-
-    let onConflict = `do update set
-        event_count = (select event_count from actor where environment_id = $4 and foreign_id = $2) + 1,
-        last_active = to_timestamp($8::double precision / 1000),
-        name        = COALESCE($5, actor.name),
-        fields      = COALESCE($11, actor.fields),
-        url         = COALESCE($10, actor.url)`;
-    if (opts.updateOnConflict === false) {
-      onConflict = "do nothing";
-    }
-
-    const q = `insert into actor (
-        id, foreign_id, project_id, environment_id, name, created, first_active, last_active, event_count, url, fields
-      ) values (
-        $1, $2, $3, $4, $5, to_timestamp($6::double precision / 1000), to_timestamp($7::double precision / 1000), to_timestamp($8::double precision / 1000), $9, $10, $11
-      ) on conflict (environment_id, foreign_id) ${onConflict}`;
-
-    const v = [
-      actor.id,
-      actor.foreign_id,
-      actor.project_id,
-      actor.environment_id,
-      actor.name,
-      actor.created,
-      actor.first_active,
-      actor.last_active,
-      actor.event_count,
-      actor.url,
-      actor.fields,
-    ];
-
-    await pg.query(q, v);
-
-    const fields = `id, environment_id, event_count, foreign_id, name, project_id, url, fields,
-      extract(epoch from created) * 1000 as created,
-      extract(epoch from first_active) * 1000 as first_active,
-      extract(epoch from last_active) * 1000 as last_active`;
-    const qq = `select ${fields} from actor where environment_id = $1 and foreign_id = $2`;
-    const vv = [opts.environmentId, opts.actor.id];
-    const result = await pg.query(qq, vv);
-    if (result.rowCount > 0) {
-      return result.rows[0];
-    }
-
-    return null;
-
-  } finally {
-    pg.release();
+  let onConflict = `do update set
+    event_count = (select event_count from actor where environment_id = $4 and foreign_id = $2) + 1,
+    last_active = to_timestamp($8::double precision / 1000),
+    name        = COALESCE($5, actor.name),
+    fields      = COALESCE($11, actor.fields),
+    url         = COALESCE($10, actor.url)`;
+  if (opts.updateOnConflict === false) {
+    onConflict = "do nothing";
   }
+
+  const q = `insert into actor (
+    id, foreign_id, project_id, environment_id, name, created, first_active, last_active, event_count, url, fields
+  ) values (
+  $1, $2, $3, $4, $5, to_timestamp($6::double precision / 1000), to_timestamp($7::double precision / 1000), to_timestamp($8::double precision / 1000), $9, $10, $11
+  ) on conflict (environment_id, foreign_id) ${onConflict}`;
+
+  const v = [
+    actor.id,
+    actor.foreign_id,
+    actor.project_id,
+    actor.environment_id,
+    actor.name,
+    actor.created,
+    actor.first_active,
+    actor.last_active,
+    actor.event_count,
+    actor.url,
+    actor.fields,
+  ];
+
+  await pg.query(q, v);
+
+  const fields = `id, environment_id, event_count, foreign_id, name, project_id, url, fields,
+  extract(epoch from created) * 1000 as created,
+  extract(epoch from first_active) * 1000 as first_active,
+  extract(epoch from last_active) * 1000 as last_active`;
+  const qq = `select ${fields} from actor where environment_id = $1 and foreign_id = $2`;
+  const vv = [opts.environmentId, opts.actor.id];
+  const result = await pg.query(qq, vv);
+  if (result.rowCount > 0) {
+    return result.rows[0];
+  }
+
+  return null;
 }

--- a/src/_processor/models/group/upsert.ts
+++ b/src/_processor/models/group/upsert.ts
@@ -1,52 +1,43 @@
 import "source-map-support/register";
 import * as moment from "moment";
+import { PoolClient } from "pg";
 
-import getPgPool from "../../persistence/pg";
+export default async function(opts, pg: PoolClient) {
+  const now = moment().valueOf();
 
-const pgPool = getPgPool();
-
-export default async function(opts) {
-  const pg = await pgPool.connect();
-  try {
-    const now = moment().valueOf();
-
-    let onConflict = `do update set
-        event_count = (select event_count from group_detail where environment_id = $3 and group_id = $4) + 1,
-        name = COALESCE($5, group_detail.name),
-        last_active = to_timestamp($1::double precision / 1000)`;
-    if (opts.updateOnConflict === false) {
-      onConflict = "do nothing";
-    }
-
-    const q = `insert into group_detail (
-        created_at, project_id, environment_id, group_id, name, last_active, event_count
-      ) values (
-        to_timestamp($1::double precision / 1000), $2, $3, $4, $5, to_timestamp($1::double precision / 1000), 1
-      ) on conflict (environment_id, group_id) ${onConflict}`;
-
-    const v = [
-      now,
-      opts.projectId,
-      opts.environmentId,
-      opts.group.id,
-      opts.group.name,
-    ];
-
-    await pg.query(q, v);
-
-    const fields = `project_id, environment_id, group_id, name, event_count,
-      extract(epoch from created_at) * 1000 as created_at,
-      extract(epoch from last_active) * 1000 as last_active`;
-    const qq = `select ${fields} from group_detail where environment_id = $1 and group_id = $2`;
-    const vv = [opts.environmentId, opts.group.id];
-    const result = await pg.query(qq, vv);
-    if (result.rowCount > 0) {
-      return result.rows[0];
-    }
-
-    return null;
-
-  } finally {
-    pg.release();
+  let onConflict = `do update set
+    event_count = (select event_count from group_detail where environment_id = $3 and group_id = $4) + 1,
+    name = COALESCE($5, group_detail.name),
+    last_active = to_timestamp($1::double precision / 1000)`;
+  if (opts.updateOnConflict === false) {
+    onConflict = "do nothing";
   }
+
+  const q = `insert into group_detail (
+    created_at, project_id, environment_id, group_id, name, last_active, event_count
+  ) values (
+  to_timestamp($1::double precision / 1000), $2, $3, $4, $5, to_timestamp($1::double precision / 1000), 1
+  ) on conflict (environment_id, group_id) ${onConflict}`;
+
+  const v = [
+    now,
+    opts.projectId,
+    opts.environmentId,
+    opts.group.id,
+    opts.group.name,
+  ];
+
+  await pg.query(q, v);
+
+  const fields = `project_id, environment_id, group_id, name, event_count,
+  extract(epoch from created_at) * 1000 as created_at,
+  extract(epoch from last_active) * 1000 as last_active`;
+  const qq = `select ${fields} from group_detail where environment_id = $1 and group_id = $2`;
+  const vv = [opts.environmentId, opts.group.id];
+  const result = await pg.query(qq, vv);
+  if (result.rowCount > 0) {
+    return result.rows[0];
+  }
+
+  return null;
 }

--- a/src/_processor/models/target/upsert.ts
+++ b/src/_processor/models/target/upsert.ts
@@ -1,77 +1,68 @@
 import "source-map-support/register";
 import * as uuid from "uuid";
 import * as moment from "moment";
+import { PoolClient } from "pg";
 
-import getPgPool from "../../persistence/pg";
+export default async function(opts, pg: PoolClient) {
+  const target = {
+    id: uuid.v4().replace(/-/g, ""),
+    foreign_id: opts.target.id,
+    project_id: opts.projectId,
+    fields: JSON.stringify(opts.target.fields),
+    environment_id: opts.environmentId,
+    name: opts.target.name,
+    created: moment().valueOf(),
+    event_count: 1,
+    url: opts.target.href,
+    first_active: moment().valueOf(),
+    last_active: moment().valueOf(),
+    type: opts.target.type,
+    retraced_object_type: "target",
+  };
 
-const pgPool = getPgPool();
-
-export default async function(opts) {
-  const pg = await pgPool.connect();
-  try {
-    const target = {
-      id: uuid.v4().replace(/-/g, ""),
-      foreign_id: opts.target.id,
-      project_id: opts.projectId,
-      fields: JSON.stringify(opts.target.fields),
-      environment_id: opts.environmentId,
-      name: opts.target.name,
-      created: moment().valueOf(),
-      event_count: 1,
-      url: opts.target.href,
-      first_active: moment().valueOf(),
-      last_active: moment().valueOf(),
-      type: opts.target.type,
-      retraced_object_type: "target",
-    };
-
-    let onConflict = `do update set
-        event_count = (select event_count from target where environment_id = $4 and foreign_id = $2) + 1,
-        name        = COALESCE($5, target.name),
-        fields      = COALESCE($12, target.fields),
-        url         = COALESCE($9, target.url),
-        last_active = to_timestamp($8::double precision / 1000)`;
-    if (opts.updateOnConflict === false) {
-      onConflict = "do nothing";
-    }
-
-    const q = `insert into target (
-        id, foreign_id, project_id, environment_id, name, created, first_active, last_active, url, type, event_count, fields
-      ) values (
-        $1, $2, $3, $4, $5, to_timestamp($6::double precision / 1000), to_timestamp($7::double precision / 1000), to_timestamp($8::double precision / 1000), $9, $10, $11, $12
-      ) on conflict (environment_id, foreign_id) ${onConflict}`;
-
-    const v = [
-      target.id,
-      target.foreign_id,
-      target.project_id,
-      target.environment_id,
-      target.name,
-      target.created,
-      target.first_active,
-      target.last_active,
-      target.url,
-      target.type,
-      target.event_count,
-      target.fields,
-    ];
-
-    await pg.query(q, v);
-
-    const fields = `id, environment_id, event_count, foreign_id, name, project_id, url, type, fields,
-        extract(epoch from created) * 1000 as created,
-        extract(epoch from first_active) * 1000 as first_active,
-        extract(epoch from last_active) * 1000 as last_active`;
-    const qq = `select ${fields} from target where environment_id = $1 and foreign_id = $2`;
-    const vv = [opts.environmentId, opts.target.id];
-    const result = await pg.query(qq, vv);
-    if (result.rowCount > 0) {
-      return result.rows[0];
-    }
-
-    return null;
-
-  } finally {
-    pg.release();
+  let onConflict = `do update set
+    event_count = (select event_count from target where environment_id = $4 and foreign_id = $2) + 1,
+    name        = COALESCE($5, target.name),
+    fields      = COALESCE($12, target.fields),
+    url         = COALESCE($9, target.url),
+    last_active = to_timestamp($8::double precision / 1000)`;
+  if (opts.updateOnConflict === false) {
+    onConflict = "do nothing";
   }
+
+  const q = `insert into target (
+    id, foreign_id, project_id, environment_id, name, created, first_active, last_active, url, type, event_count, fields
+  ) values (
+  $1, $2, $3, $4, $5, to_timestamp($6::double precision / 1000), to_timestamp($7::double precision / 1000), to_timestamp($8::double precision / 1000), $9, $10, $11, $12
+  ) on conflict (environment_id, foreign_id) ${onConflict}`;
+
+  const v = [
+    target.id,
+    target.foreign_id,
+    target.project_id,
+    target.environment_id,
+    target.name,
+    target.created,
+    target.first_active,
+    target.last_active,
+    target.url,
+    target.type,
+    target.event_count,
+    target.fields,
+  ];
+
+  await pg.query(q, v);
+
+  const fields = `id, environment_id, event_count, foreign_id, name, project_id, url, type, fields,
+  extract(epoch from created) * 1000 as created,
+  extract(epoch from first_active) * 1000 as first_active,
+  extract(epoch from last_active) * 1000 as last_active`;
+  const qq = `select ${fields} from target where environment_id = $1 and foreign_id = $2`;
+  const vv = [opts.environmentId, opts.target.id];
+  const result = await pg.query(qq, vv);
+  if (result.rowCount > 0) {
+    return result.rows[0];
+  }
+
+  return null;
 }

--- a/src/_processor/workers/normalizeEvent.ts
+++ b/src/_processor/workers/normalizeEvent.ts
@@ -67,7 +67,7 @@ export default async function normalizeEvent(job) {
         projectId: task.project_id,
         environmentId: task.environment_id,
         updateOnConflict: processingNewEvent,
-      });
+      }, pg);
     }
 
     let actor;
@@ -77,7 +77,7 @@ export default async function normalizeEvent(job) {
         projectId: task.project_id,
         environmentId: task.environment_id,
         updateOnConflict: processingNewEvent,
-      });
+      }, pg);
     }
 
     let target;
@@ -87,7 +87,7 @@ export default async function normalizeEvent(job) {
         projectId: task.project_id,
         environmentId: task.environment_id,
         updateOnConflict: processingNewEvent === true,
-      });
+      }, pg);
     }
 
     await upsertAction({
@@ -95,7 +95,7 @@ export default async function normalizeEvent(job) {
       projectId: task.project_id,
       environmentId: task.environment_id,
       updateOnConflict: processingNewEvent === true,
-    });
+    }, pg);
 
     let locInfo;
     if (origEvent.source_ip) {

--- a/src/persistence/pg.ts
+++ b/src/persistence/pg.ts
@@ -13,7 +13,7 @@ export default function getPgPool(): pg.Pool {
       password: process.env.POSTGRES_PASSWORD,
       host: process.env.POSTGRES_HOST,
       port: Number(process.env.POSTGRES_PORT),
-      max: Number(process.env.POSTGRES_POOL_SIZE) || 10,
+      max: Number(process.env.POSTGRES_POOL_SIZE) || 20,
       idleTimeoutMillis: Number(process.env.PUBLISHER_CREATE_EVENT_TIMEOUT) || 2000, // how long a client is allowed to remain idle before being closed
     });
 


### PR DESCRIPTION
The normalizeEvent worker was using a single long-lived connection plus
four short-lived connections, i.e.  2 concurrent connections for most of the
lifetime of the job.  Five normalizeWorker jobs can be in-flight at
once, for a total of 10 concurrent connections, which was the default
limit on the pool.

This changes the normalizeEvent worker to use a single connection for
all queries. Also raise the default pool connection limit to 20.

The current staging stats from nsq for the topic/channel show that the backlog is not falling because more jobs are timing out than are succeeding.
```
   [raw_events     ] depth: 0     be-depth: 0     msgs: 631525   e2e%:
      [normalize                ] depth: 631496 be-depth: 621496 inflt: 10   def: 0    re-q: 0     timeout: 5070  msgs: 631525   e2e%:
        [V2 processor-7644db694d-kbngm] state: 3 inflt: 5    rdy: 5    fin: 18       re-q: 0        msgs: 2558     connected: 4h14m57s
```

DataDog is showing the current p95 wait time for a connection from the pool is 11s. This PR is expected to fix both the timeouts for the job and the wait time for getting a connection.