### PR TITLE
include the URL in the 404 log line

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ function buildRoutes() {
 
   app.use((req, res, next) => {
     const errMsg = "Not Found";
-    logger.error(`[${req.ip}] ${errMsg}`);
+    logger.error(`[${req.ip}] ${req.path} ${errMsg}`);
     res.status(404).send(errMsg);
   });
 


### PR DESCRIPTION
there's a lot of these in the logs, and it would be nice to see what from:

```
{"pid":1,"hostname":"api-6c895c7459-jwxmw","level":50,"time":1581975529263,"msg":"[10.33.128.14] Not Found","v":1}
```