### PR TITLE
include retraceddb4G in container

### DIFF
--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 EXPOSE 3000
 
 COPY --from=node /src/retraceddb /src/retraceddb
+COPY --from=node /src/retraceddb4G /src/retraceddb4G
 copy --from=node /src/migrations/pg /src/migrations/pg
 copy --from=node /src/migrations/pg10 /src/migrations/pg10
 copy --from=node /src/migrations/pg /src/migrations/pg10


### PR DESCRIPTION
pkg does not allow setting node options at runtime, so this is needed if you run out of memory