### PR TITLE
Resolve CVEs

### DIFF
--- a/deploy/Dockerfile-postgres
+++ b/deploy/Dockerfile-postgres
@@ -1,4 +1,4 @@
-FROM postgres:10.21-alpine
+FROM postgres:10.23-alpine
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
Know CVEs at the time of this PR

In retraced:1.3.52 image

```
NAME              INSTALLED                FIXED-IN                 VULNERABILITY   SEVERITY 
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc6             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libgssapi-krb5-2  1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libk5crypto3      1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libkrb5-3         1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libkrb5support0   1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libncursesw6      6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
libtinfo6         6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
ncurses-base      6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
ncurses-bin       6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
zlib1g            1:1.2.11.dfsg-1+deb10u1  1:1.2.11.dfsg-1+deb10u2  CVE-2022-37434  Critical  
1 error occurred:
	* discovered vulnerabilities at or above the severity threshold
```

In retraced-postgres:1.3.52 image

```
NAME       INSTALLED  FIXED-IN   VULNERABILITY   SEVERITY 
krb5-libs  1.19.3-r0  1.19.4-r0  CVE-2022-42898  Unknown   
libxml2    2.9.14-r0  2.9.14-r1  CVE-2022-2309   High      
libxml2    2.9.14-r0  2.9.14-r2  CVE-2022-40303  High      
libxml2    2.9.14-r0  2.9.14-r2  CVE-2022-40304  High      
1 error occurred:
	* discovered vulnerabilities at or above the severity threshold
```

In retraced-nsq:1.3.52 image

```
NAME          INSTALLED                FIXED-IN                 VULNERABILITY   SEVERITY 
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc-bin      2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libc6         2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libncursesw6  6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
libtinfo6     6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
ncurses-base  6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
ncurses-bin   6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
zlib1g        1:1.2.11.dfsg-1+deb10u1  1:1.2.11.dfsg-1+deb10u2  CVE-2022-37434  Critical  
1 error occurred:
	* discovered vulnerabilities at or above the severity threshold
```