### PR TITLE
Added admin_token to bypass user and project specific queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ experimental:
 defaults: &defaults
   resource_class: large
   docker:
-    - image: cimg/node:16.16
+    - image: cimg/node:16.18
   working_directory: ~/repo
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:16.16.0 as node
+FROM --platform=$BUILDPLATFORM node:16.18.1 as node
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -4,8 +4,8 @@
 FROM debian:buster-slim as cron
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
+  ca-certificates \
+  curl \
   && rm -rf /var/lib/apt/lists/*
 
 
@@ -13,16 +13,16 @@ ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.
 ENV SUPERCRONIC=supercronic-linux-amd64
 ENV SUPERCRONIC_SHA1SUM=048b95b48b708983effb2e5c935a1ef8483d9e3e
 RUN curl -fsSLO "$SUPERCRONIC_URL" \
-    && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
-    && chmod +x "$SUPERCRONIC" \
-    && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
-    && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/replicated-auditlog-cron
+  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+  && chmod +x "$SUPERCRONIC" \
+  && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+  && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/replicated-auditlog-cron
 COPY deploy/crontab /crontab
 
 # # #
 # Node build
 #
-FROM node:16.16.0 as node
+FROM node:16.18.1 as node
 
 WORKDIR /src
 ADD package.json /src
@@ -49,11 +49,11 @@ RUN make pkg SKIP=${skip_pkg}
 FROM debian:buster-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    \
-    \
-    libp11-kit0 \
+  ca-certificates \
+  curl \
+  \
+  \
+  libp11-kit0 \
   && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 3000

--- a/src/handlers/admin/getProject.ts
+++ b/src/handlers/admin/getProject.ts
@@ -1,9 +1,8 @@
-
 import { checkAdminAccess } from "../../security/helpers";
 import getProject from "../../models/project/get";
 import hydrateProject from "../../models/project/hydrate";
 
-export default async function(req) {
+export default async function (req) {
   await checkAdminAccess(req);
 
   const project = await getProject(req.params.projectId);

--- a/src/handlers/admin/listProjects.ts
+++ b/src/handlers/admin/listProjects.ts
@@ -1,14 +1,16 @@
-
 import { checkAdminAccess } from "../../security/helpers";
 import listProjects from "../../models/project/list";
+import listAllProjects from "../../models/project/listall";
 import hydrateProject from "../../models/project/hydrate";
 
-export default async function(req) {
+export default async function (req) {
   const claims = await checkAdminAccess(req);
 
-  const projects = await listProjects({
-    user_id: claims.userId,
-  });
+  const projects = claims.adminToken
+    ? await listAllProjects()
+    : await listProjects({
+        user_id: claims.userId,
+      });
 
   const hydratedProjects: any[] = [];
   for (const projId in projects) {

--- a/src/models/project/listall.ts
+++ b/src/models/project/listall.ts
@@ -1,0 +1,18 @@
+import getPgPool from "../../persistence/pg";
+
+const pgPool = getPgPool();
+
+export interface Options {
+  user_id: string;
+}
+
+/**
+ * Asynchronously returns all projects for a user from the database
+ */
+export default async function listAllProjects() {
+  const q = `select project.* from project`;
+
+  const result = await pgPool.query(q);
+
+  return result.rowCount > 0 ? result.rows : [];
+}

--- a/src/models/project/listall.ts
+++ b/src/models/project/listall.ts
@@ -2,10 +2,6 @@ import getPgPool from "../../persistence/pg";
 
 const pgPool = getPgPool();
 
-export interface Options {
-  user_id: string;
-}
-
 /**
  * Asynchronously returns all projects for a user from the database
  */

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -53,7 +53,6 @@ import viewerUpdateEitapiToken from "./handlers/viewer/updateEitapiToken";
 import viewerUpdateExport from "./handlers/viewer/updateExport";
 
 export default {
-
   publisherGraphQLGet: {
     path: "/publisher/v1/graphql",
     method: "get",
@@ -288,12 +287,12 @@ export default {
     handler: enterpriseSearchAdHoc,
   },
 
-//
   //
-    // OLD ROUTES -- DONT DOCUMENT, DEPRECATE SOON
-      //
-        //
-          //
+  //
+  // OLD ROUTES -- DONT DOCUMENT, DEPRECATE SOON
+  //
+  //
+  //
 
   //
   // core

--- a/src/security/vouchers.ts
+++ b/src/security/vouchers.ts
@@ -5,6 +5,7 @@ import ViewerDescriptor from "../models/viewer_descriptor/def";
 
 export interface AdminClaims {
   userId: string;
+  adminToken?: string;
 }
 
 export function createAdminVoucher(claims: AdminClaims): string {
@@ -17,7 +18,9 @@ export function createViewerDescriptorVoucher(desc: ViewerDescriptor): string {
   return jwt.sign(desc, config.HMAC_SECRET_VIEWER);
 }
 
-export async function validateAdminVoucher(voucher: string): Promise<AdminClaims> {
+export async function validateAdminVoucher(
+  voucher: string
+): Promise<AdminClaims> {
   return new Promise<AdminClaims>((resolve, reject) => {
     jwt.verify(voucher, config.HMAC_SECRET_ADMIN, (err, claims) => {
       if (err) {
@@ -29,7 +32,9 @@ export async function validateAdminVoucher(voucher: string): Promise<AdminClaims
   });
 }
 
-export async function validateViewerDescriptorVoucher(voucher: string): Promise<ViewerDescriptor> {
+export async function validateViewerDescriptorVoucher(
+  voucher: string
+): Promise<ViewerDescriptor> {
   return new Promise<ViewerDescriptor>((resolve, reject) => {
     jwt.verify(voucher, config.HMAC_SECRET_VIEWER, (err, claims) => {
       if (err) {


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

Projects created during the bootstrap phase (without a user) don't appear in the API list. Added an `admin_token` param to Authorization header to bypass user and project filters.
