### PR TITLE
add volumes for scratch directories

### DIFF
--- a/deploy/Dockerfile-nsq
+++ b/deploy/Dockerfile-nsq
@@ -14,6 +14,7 @@ EXPOSE 4150 4151 4160 4161 4170 4171
 
 VOLUME /data
 VOLUME /etc/ssl/certs
+VOLUME /home
 
 COPY --from=0 /usr/local/bin/ /usr/local/bin/
 

--- a/deploy/Dockerfile-postgres
+++ b/deploy/Dockerfile-postgres
@@ -8,3 +8,5 @@ RUN apk add --update --no-cache \
     apk-tools \
     openssl \
     libgcrypt
+
+VOLUME /var/run/postgresql

--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -78,6 +78,7 @@ RUN ln -s /src/processor /src/replicated-auditlog-processor
 RUN ln -s /src/bin/retracedctl /src/replicated-auditlog-retracedctl
 RUN ln -s /src/retraceddb /src/replicated-auditlog-migrations
 
+VOLUME /src/auth0
 WORKDIR /src
 
 RUN chmod a+rwx /src # auth0 writes to pwd


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

Currently, Retraced containers cannot run with a readonly root fs without additional volume mounts for scratch data. This adds those volumes to the dockerfiles.

# Does your change fix a particular issue?

Fixes #(issue)
