### PR TITLE
Flag to skip logging of the view audit log event

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -68,4 +68,5 @@ export default {
     env.RETRACED_NO_ANALYTICS ||
     process.env.DO_NOT_TRACK ||
     env.DO_NOT_TRACK,
+  SKIP_VIEW_LOG_EVENT: process.env.SKIP_VIEW_LOG_EVENT || env.SKIP_VIEW_LOG_EVENT,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,5 +68,4 @@ export default {
     env.RETRACED_NO_ANALYTICS ||
     process.env.DO_NOT_TRACK ||
     env.DO_NOT_TRACK,
-  SKIP_VIEW_LOG_EVENT: process.env.SKIP_VIEW_LOG_EVENT || env.SKIP_VIEW_LOG_EVENT,
 };

--- a/src/handlers/viewer/graphql.ts
+++ b/src/handlers/viewer/graphql.ts
@@ -1,6 +1,7 @@
 import querystring from "querystring";
 import { checkViewerAccess } from "../../security/helpers";
 import { defaultEventCreater, CreateEventRequest } from "../createEvent";
+import config from "../../config";
 
 import handler from "../graphql/handler";
 
@@ -36,7 +37,9 @@ export default async function (req) {
     targetId,
   });
 
-  await defaultEventCreater.saveRawEvent(claims.projectId, claims.environmentId, thisViewEvent);
+  if (!config.SKIP_VIEW_LOG_EVENT) {
+    await defaultEventCreater.saveRawEvent(claims.projectId, claims.environmentId, thisViewEvent);
+  }
 
   return results;
 }

--- a/src/handlers/viewer/graphql.ts
+++ b/src/handlers/viewer/graphql.ts
@@ -1,7 +1,6 @@
 import querystring from "querystring";
 import { checkViewerAccess } from "../../security/helpers";
 import { defaultEventCreater, CreateEventRequest } from "../createEvent";
-import config from "../../config";
 
 import handler from "../graphql/handler";
 
@@ -37,7 +36,7 @@ export default async function (req) {
     targetId,
   });
 
-  if (!config.SKIP_VIEW_LOG_EVENT) {
+  if (!req.query.skipViewLogEvent) {
     await defaultEventCreater.saveRawEvent(claims.projectId, claims.environmentId, thisViewEvent);
   }
 

--- a/src/handlers/viewer/searchEvents.ts
+++ b/src/handlers/viewer/searchEvents.ts
@@ -8,6 +8,7 @@ import searchEvents, { Options } from "../../models/event/search";
 import nsq from "../../persistence/nsq";
 import addDisplayTitles from "../../models/event/addDisplayTitles";
 import { defaultEventCreater, CreateEventRequest } from "../createEvent";
+import config from "../../config";
 
 /*
 What we're expecting from clients:
@@ -101,7 +102,10 @@ export default async function (req) {
     });
     await nsq.produce("user_reporting_task", job);
   }
-  defaultEventCreater.saveRawEvent(req.params.projectId, claims.environmentId, thisViewEvent);
+
+  if (!config.SKIP_VIEW_LOG_EVENT) {
+    defaultEventCreater.saveRawEvent(req.params.projectId, claims.environmentId, thisViewEvent);
+  }
 
   return {
     status: 200,

--- a/src/handlers/viewer/searchEvents.ts
+++ b/src/handlers/viewer/searchEvents.ts
@@ -8,7 +8,6 @@ import searchEvents, { Options } from "../../models/event/search";
 import nsq from "../../persistence/nsq";
 import addDisplayTitles from "../../models/event/addDisplayTitles";
 import { defaultEventCreater, CreateEventRequest } from "../createEvent";
-import config from "../../config";
 
 /*
 What we're expecting from clients:
@@ -103,7 +102,7 @@ export default async function (req) {
     await nsq.produce("user_reporting_task", job);
   }
 
-  if (!config.SKIP_VIEW_LOG_EVENT) {
+  if (!req.body.skipViewLogEvent) {
     defaultEventCreater.saveRawEvent(req.params.projectId, claims.environmentId, thisViewEvent);
   }
 


### PR DESCRIPTION
## Flag to skip View Audit log event

Created a flag `SKIP_VIEW_LOG_EVENT` environment variable
By default, it will be disabled
When it's set to 1 or true it will not log the `View Log Event` audit log.
