### PR TITLE
API to delete viewer sessions

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -20,7 +20,7 @@ dev:
         cpu: "2"
         memory: 1Gi
     forward:
-      - 2353:2345
+      - 3353:2345
     persistentVolume:
       enabled: true
       size: 1Gi

--- a/src/handlers/revokeViewerSessions.ts
+++ b/src/handlers/revokeViewerSessions.ts
@@ -1,0 +1,32 @@
+import Authenticator from "../security/Authenticator";
+import modelDeleteViewerDescriptors from "../models/viewer_descriptor/delete";
+import { RawResponse } from "../router";
+
+export default async function handlerRaw(req): Promise<RawResponse> {
+  const auth = req.get("Authorization");
+  const projectId = req.params.projectId;
+  const groupId = req.params.groupId;
+  const actorId = req.params.actorId;
+  await revokeViewerSessions(auth, projectId, actorId, groupId);
+  return {
+      status: 200,
+      body: "",
+  };
+}
+
+export async function revokeViewerSessions(
+  auth: string,
+  projectId: string,
+  actorId: string,
+  groupId: string,
+): Promise<void> {
+
+  const apiToken = await Authenticator.default().getApiTokenOr401(auth, projectId);
+
+  await modelDeleteViewerDescriptors({
+    projectId,
+    environmentId: apiToken.environmentId,
+    groupId,
+    actorId,
+  });
+}

--- a/src/models/viewer_descriptor/delete.ts
+++ b/src/models/viewer_descriptor/delete.ts
@@ -1,0 +1,27 @@
+import getPgPool from "../../persistence/pg";
+
+const pgPool = getPgPool();
+
+export interface Options {
+    projectId: string;
+    environmentId: string;
+    groupId: string;
+    actorId: string;
+}
+
+export default async function modelDeleteViewerDescriptors(opts: Options): Promise<void> {
+    const q = `
+        DELETE FROM viewer_descriptors
+        WHERE project_id = $1 AND
+            environment_id = $2 AND
+            group_id = $3 AND
+            actor_id = $4`;
+    const values = [
+        opts.projectId,
+        opts.environmentId,
+        opts.groupId,
+        opts.actorId,
+    ];
+
+    await pgPool.query(q, values);
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,6 +1,7 @@
 // core
 import createAdminSession from "./handlers/createAdminSession";
 import createViewerDescriptor from "./handlers/createViewerDescriptor";
+import revokeViewerSessions from "./handlers/revokeViewerSessions";
 import createViewerSession from "./handlers/createViewerSession";
 import getInvite from "./handlers/getInvite";
 import graphQL from "./handlers/graphql";
@@ -312,6 +313,11 @@ export default {
     path: "/v1/viewersession",
     method: "post",
     handler: createViewerSession,
+  },
+  revokeViewerSessions: {
+    path: "/v1/project/:projectId/group/:groupId/actor/:actorId/viewersessions",
+    method: "delete",
+    handler: revokeViewerSessions,
   },
   getInvite: {
     path: "/v1/invite",

--- a/src/security/vouchers.ts
+++ b/src/security/vouchers.ts
@@ -1,6 +1,7 @@
 import * as jwt from "jsonwebtoken";
 
 import ViewerDescriptor from "../models/viewer_descriptor/def";
+import getViewerToken from "../models/viewer_descriptor/get";
 
 export interface AdminClaims {
   userId: string;
@@ -29,7 +30,7 @@ export async function validateAdminVoucher(voucher: string): Promise<AdminClaims
 }
 
 export async function validateViewerDescriptorVoucher(voucher: string): Promise<ViewerDescriptor> {
-  return new Promise<ViewerDescriptor>((resolve, reject) => {
+  const claims = await new Promise<ViewerDescriptor>((resolve, reject) => {
     jwt.verify(voucher, process.env.HMAC_SECRET_VIEWER, (err, claims) => {
       if (err) {
         reject(err);
@@ -38,4 +39,14 @@ export async function validateViewerDescriptorVoucher(voucher: string): Promise<
       resolve(claims);
     });
   });
+
+  const token = await getViewerToken({
+    id: claims.id,
+  });
+
+  if (!token) {
+    throw new Error("Invalid token");
+  }
+
+  return claims
 }


### PR DESCRIPTION
This add API to delete all viewer sessions for a given actor.  This can be used when user logs out or when a user is removed from an organization.