### PR TITLE
Bobbawn/sc 92261/audit log graphql api field duplication query

### DIFF
--- a/src/handlers/graphql/handler.ts
+++ b/src/handlers/graphql/handler.ts
@@ -3,6 +3,7 @@ import "source-map-support/register";
 import { Scope } from "../../security/scope";
 import schema from "./schema";
 import { graphql } from "graphql";
+import { specifiedRules } from "graphql/validation";
 
 export default async function(req, context: Scope) {
   const query = req.body.query || req.query.query;
@@ -22,3 +23,32 @@ export default async function(req, context: Scope) {
     body: JSON.stringify(result),
   };
 }
+
+/*
+ * Custom validator to disallow duplicate fields in a query.
+ * This validator protects against various denial of service attacks:
+ * 1. Field duplication
+ * 2. Alias attack
+ * 3. Deep-recursive queries
+ * 4. Circular fragments
+ *
+ * See https://medium.com/@ibm_ptc_security/denial-of-service-attacks-with-graphql-77189a6ba85b
+ */
+export function NoDuplicateFields(context) {
+    const fields = new Set<String>();
+    return {
+        Field: (node) => {
+            const type = context.getParentType();
+            const fieldDef = context.getFieldDef();
+            const field = type + ":" + fieldDef.name;
+            if (fields[field]) {
+                context.reportError(new Error(`Duplicate field ${field}.`));
+                return;
+              }
+            fields[field] = true;
+        },
+    };
+}
+
+specifiedRules.push(NoDuplicateFields);
+

--- a/src/handlers/viewer/graphql.ts
+++ b/src/handlers/viewer/graphql.ts
@@ -6,7 +6,6 @@ import { defaultEventCreater, CreateEventRequest } from "../createEvent";
 import handler from "../graphql/handler";
 
 export default async function(req) {
-  console.log("graphql viewer, req: ", req);
   const claims = await checkViewerAccess(req);
   const thisViewEvent: CreateEventRequest = {
     action: claims.viewLogAction,

--- a/src/handlers/viewer/graphql.ts
+++ b/src/handlers/viewer/graphql.ts
@@ -6,6 +6,7 @@ import { defaultEventCreater, CreateEventRequest } from "../createEvent";
 import handler from "../graphql/handler";
 
 export default async function(req) {
+  console.log("graphql viewer, req: ", req);
   const claims = await checkViewerAccess(req);
   const thisViewEvent: CreateEventRequest = {
     action: claims.viewLogAction,

--- a/src/test/handlers/graphql.ts
+++ b/src/test/handlers/graphql.ts
@@ -6,7 +6,6 @@ import { parse, validate } from "graphql";
 import { specifiedRules } from "graphql/validation";
 
 specifiedRules.push(NoDuplicateFields);
-console.log("initializing specifiedRules: ", specifiedRules);
 
 @suite class GraphqlTest {
     @test public async "Graphql#validateValidFullSearch()"() {
@@ -69,6 +68,7 @@ console.log("initializing specifiedRules: ", specifiedRules);
         var documentAST = parse(query);
         const errors = validate(schema, documentAST);
         expect(errors).to.not.be.empty;
+        expect(String(errors[0])).to.have.string("Error: Duplicate field EventsConnection:totalCount.");
     }
 
     @test public async "Graphql#validateAliasOverload()"() {
@@ -79,6 +79,7 @@ console.log("initializing specifiedRules: ", specifiedRules);
         var documentAST = parse(query);
         const errors = validate(schema, documentAST);
         expect(errors).to.not.be.empty;
+        expect(String(errors[0])).to.have.string("Error: Duplicate field EventsConnection:totalCount.");
     }
 }
 

--- a/src/test/handlers/graphql.ts
+++ b/src/test/handlers/graphql.ts
@@ -1,0 +1,84 @@
+import { suite, test } from "mocha-typescript";
+import { expect } from "chai";
+import { NoDuplicateFields } from "../../handlers/graphql/handler";
+import schema from "../../handlers/graphql/schema";
+import { parse, validate } from "graphql";
+import { specifiedRules } from "graphql/validation";
+
+specifiedRules.push(NoDuplicateFields);
+console.log("initializing specifiedRules: ", specifiedRules);
+
+@suite class GraphqlTest {
+    @test public async "Graphql#validateValidFullSearch()"() {
+        const query = `
+      query Search($query: String!, $last: Int, $before: String) {
+        search(query: $query, last: $last, before: $before) {
+          totalCount
+          pageInfo {
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              action
+              crud
+              created
+              received
+              canonical_time
+              description
+              actor {
+                id
+                name
+                href
+              }
+              group {
+                id
+                name
+              }
+              target {
+                id
+                name
+                href
+                type
+              }
+              display {
+                markdown
+              }
+              is_failure
+              is_anonymous
+              source_ip
+              country
+              loc_subdiv1
+              loc_subdiv2
+            }
+          }
+        }
+      }`;
+
+        var documentAST = parse(query);
+        const errors = validate(schema, documentAST);
+        expect(errors).to.be.empty;
+    }
+
+    @test public async "Graphql#validateDupFields()"() {
+        const query = `
+        query Search($query: String!, $last: Int, $before: String) {
+          search(query: $query, last: $last, before: $before) { totalCount totalCount }
+        }`;
+        var documentAST = parse(query);
+        const errors = validate(schema, documentAST);
+        expect(errors).to.not.be.empty;
+    }
+
+    @test public async "Graphql#validateAliasOverload()"() {
+        const query = `
+        query Search($query: String!, $last: Int, $before: String) {
+          search(query: $query, last: $last, before: $before) { a1:totalCount a2:totalCount }
+        }`;
+        var documentAST = parse(query);
+        const errors = validate(schema, documentAST);
+        expect(errors).to.not.be.empty;
+    }
+}
+


### PR DESCRIPTION
# Fix DoS Vulnerability in GraphQL endpoint

Add a validation rule to reject potential DoS requests detected by pen test. Rule prohibits duplicate fields in graphql queries. This guards against both simple field duplication and aliasing attacks.

# Does your change fix a particular issue?

https://app.shortcut.com/replicated/story/92261/audit-log-graphql-api-field-duplication-query-leads-to-denial-of-service
https://app.shortcut.com/replicated/story/92268/audit-log-graphql-api-alias-overloading-query-leads-to-denial-of-service
