### PR TITLE
CVE fixes

### DIFF
--- a/.circleci/.anchore/grype.yaml
+++ b/.circleci/.anchore/grype.yaml
@@ -1,4 +1,6 @@
 ignore:
+  - vulnerability: CVE-2023-47038
+  - vulnerability: CVE-2023-5981
 
   # https://github.com/anchore/grype#specifying-matches-to-ignore
   # example to ignore a vulnerability

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,13 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
   build_docker:
-    <<: *defaults
+    docker:
+      - image: cimg/base:2023.12
     working_directory: ~/repo
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.14
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}
@@ -56,11 +57,12 @@ jobs:
             - ./retraced.tar
 
   build_postgres:
-    <<: *defaults
+    docker:
+      - image: cimg/base:2023.12
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.14
       - run: docker build --pull -t registry.replicated.com/library/retraced-postgres:${CIRCLE_SHA1:0:7} -f deploy/Dockerfile-postgres .
       - run:
           name: Run local image vulnerability scan
@@ -74,11 +76,12 @@ jobs:
             - ./retraced-postgres.tar
 
   build_nsq:
-    <<: *defaults
+    docker:
+      - image: cimg/base:2023.12
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.14
       - run: docker build --pull -t registry.replicated.com/library/retraced-nsq:${CIRCLE_SHA1:0:7} -f deploy/Dockerfile-nsq .
       - run:
           name: Run local image vulnerability scan

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ scan-nsq: IMAGE=registry.replicated.com/library/retraced-nsq:local
 scan-nsq: DOCKERFILE=./deploy/Dockerfile-nsq
 scan-nsq: grype
 	docker build --pull -t ${IMAGE} -f ${DOCKERFILE} .
-	./grype --fail-on=medium --only-fixed -vv ${IMAGE}
+	./grype --fail-on=medium --only-fixed --config=.circleci/.anchore/grype.yaml -vv ${IMAGE}
 
 scan-postgres: IMAGE=registry.replicated.com/library/retraced-postgres:local
 scan-postgres: DOCKERFILE=./deploy/Dockerfile-postgres
@@ -103,6 +103,6 @@ scan-api: IMAGE=registry.replicated.com/library/retraced:local
 scan-api: DOCKERFILE=./deploy/Dockerfile-slim
 scan-api: grype
 	docker build --pull -t ${IMAGE} -f ${DOCKERFILE} .
-	./grype --fail-on=medium --only-fixed -vv ${IMAGE}
+	./grype --fail-on=medium --only-fixed --config=.circleci/.anchore/grype.yaml -vv ${IMAGE}
 
 scan: scan-nsq scan-postgres scan-api

--- a/deploy/Dockerfile-nsq
+++ b/deploy/Dockerfile-nsq
@@ -1,6 +1,6 @@
 FROM nsqio/nsq:v1.0.0-compat
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     \

--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -1,7 +1,7 @@
 # # #
 # Cron build
 #
-FROM debian:buster-slim as cron
+FROM debian:bookworm-slim as cron
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -51,7 +51,7 @@ RUN make pkg SKIP=${skip_pkg}
 # Main build
 #
 # curl must be included for cron
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

- Updating base images to latest Debian
- Two CVE fixes are not yet available, adding those to ignore list.

```
[0006]  INFO ignoring 80 matches due to user-provided ignore rules
NAME         INSTALLED  FIXED-IN          TYPE  VULNERABILITY   SEVERITY 
libgnutls30  3.7.9-2    3.7.9-2+deb12u1   deb   CVE-2023-5981   Medium    
perl-base    5.36.0-7   5.36.0-7+deb12u1  deb   CVE-2023-47038  Unknown
[0006] ERROR 1 error occurred:
        * discovered vulnerabilities at or above the severity threshold
```

# Does your change fix a particular issue?

Fixes #(issue)
