### PR TITLE
Support JWT value in request headers and queries for data export

### DIFF
--- a/src/handlers/viewer/renderSavedExport.ts
+++ b/src/handlers/viewer/renderSavedExport.ts
@@ -1,15 +1,16 @@
 import { validateViewerDescriptorVoucher } from "../../security/vouchers";
+import { checkViewerAccess } from "../../security/helpers";
 import renderSavedExport from "../../models/saved_export/render";
+import ViewerDescriptor from "../../models/viewer_descriptor/def";
 
 export default async function(req) {
-  // Note that this call needs the JWT passed in as a query string param.
-  // This is because we will be calling this from window.open() in a browser,
-  // and there's no way to set headers in that circumstance.
-  //
-  // TODO
-  // Leaking the JWT is bad though, ideally this should use a single-use
-  // nonce instead
-  const claims = await validateViewerDescriptorVoucher(req.query.jwt);
+  // Older viewers will pass JWT in request query. Newer viewers will pass JWT in the authorization header.
+  let claims: ViewerDescriptor;
+  if (req.query.jwt) {
+    claims = await validateViewerDescriptorVoucher(req.query.jwt);
+  } else {
+    claims = await checkViewerAccess(req);
+  }
 
   const format = req.query.format || "csv";
   let contentType;

--- a/src/router.ts
+++ b/src/router.ts
@@ -53,6 +53,7 @@ export const onSuccess =
       const respObj = res.status(statusToSend).type(contentType).set("X-Retraced-RequestId", reqId);
       if (result.filename) {
         respObj.attachment(result.filename);
+        respObj.set("Access-Control-Expose-Headers", "Content-Disposition"); // needed for CORS to work
       }
       if (result.headers) {
         _.forOwn(result.headers, (value, key) => {


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

Passing JWT values in request query parameters isn't safe because this data can be leaked (for example in log aggregators).

Right now the API for exporting data only supports JWT passing via query parameters, leaving clients that wish to use more secure options no other choice. This PR adds support for both methods for backwards compatibility.

# Does your change fix a particular issue?

Fixes #(issue)
