### PR TITLE
Missing else when rebuilding index

### DIFF
--- a/src/_db/commands/reindex/postgres.ts
+++ b/src/_db/commands/reindex/postgres.ts
@@ -82,16 +82,17 @@ export const handler = async (argv) => {
   let currentIndices: string[] = [];
   if (!aliasesBlob) {
     logger.error({msg: "no aliasesBlob"});
+  } else {
+    aliasesBlob.split("\n").forEach((aliasDesc) => {
+      const parts = aliasDesc.split(" ");
+      if (parts.length >= 2) {
+        currentIndices.push(parts[1]);
+      }
+    });
+    logger.info({msg: "found current read indices",
+      count: currentIndices.length,
+    });
   }
-  aliasesBlob.split("\n").forEach((aliasDesc) => {
-    const parts = aliasDesc.split(" ");
-    if (parts.length >= 2) {
-      currentIndices.push(parts[1]);
-    }
-  });
-  logger.info({msg: "found current read indices",
-    count: currentIndices.length,
-  });
 
   const aliasesBlobWrite = await es.cat.aliases({ name: esTargetWriteIndex });
   let currentIndicesWrite: string[] = [];


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

This change addresses the exception below:

```
{"pid":1,"hostname":"reindex-retraced-5g2zh","level":30,"time":1709231600958,"msg":"computed new index names","esTempIndex":"retraced.reindex.40a31f99-dffa-48cc-9052-338259a31c5a","esTargetIndex":"retraced.51e79795f89b4454a883a3a49d03d6ea.7a691d01114a494ba9d77eb302edce6a","esTargetWriteIndex":"retraced.51e79795f89b4454a883a3a49d03d6ea.7a691d01114a494ba9d77eb302edce6a.current","v":1}
{"pid":1,"hostname":"reindex-retraced-5g2zh","level":50,"time":1709231600984,"msg":"no aliasesBlob","v":1}
(node:1) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'split' of undefined
    at Object.exports.handler (/snapshot/src/build/_db/commands/reindex/postgres.js:0)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
```

# Does your change fix a particular issue?

Fixes #(issue)
