### PR TITLE
Handle 400 error from ES

### DIFF
--- a/src/_processor/workers/saveEventToElasticsearch.ts
+++ b/src/_processor/workers/saveEventToElasticsearch.ts
@@ -35,6 +35,12 @@ export class ElasticsearchSaver {
 
     const alias = `retraced.${jobObj.projectId}.${jobObj.environmentId}.current`;
     try {
+      // Old events may have "<nil>" as the expiration date. We still need to save them.
+      if (event.fields && event.fields["expiration_date"] === "<nil>") {
+        console.log("Deleting expiration_date field because it's invalid.");
+        delete event.fields["expiration_date"];
+      }
+
       await this.esIndex(event, alias);
     } catch (e) {
       e.retry = true;


### PR DESCRIPTION
Thank you for contributing to Retraced!

There are old events stuck in the NSQ that have invalid `expiration_date` values. This prevents ElasticSearch from saving them because it's a mapped field of type `date`

# Please add a summary of your change

This is a targeted fix to remove invalid values that still preserves audit log events.

# Does your change fix a particular issue?

Fixes #(issue)
