### PR TITLE
chore: Update artifact download action to use version 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,12 +242,12 @@ jobs:
           sbom-artifact-match: ".*\\.cyclonedx$"
       - name: Download artifact for SPDX Report
         if: github.ref == 'refs/heads/release'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: retraced_sbom.spdx
       - name: Download artifact for CycloneDx Report
         if: github.ref == 'refs/heads/release'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: retraced_sbom.cyclonedx
       - name: Remove older SBOMs
@@ -288,12 +288,12 @@ jobs:
           sbom-artifact-match: ".*\\.cyclonedx$"
       - name: Download artifact for SPDX Report [Docker]
         if: github.ref == 'refs/heads/release'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker_sbom.spdx
       - name: Download artifact for CycloneDx Report [Docker]
         if: github.ref == 'refs/heads/release'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker_sbom.cyclonedx
       - name: Create/Clear folder [Docker]


### PR DESCRIPTION
The artifact download action in the GitHub workflow has been updated to use version 4 of the `actions/download-artifact` action. This change ensures compatibility with the latest version of the action and improves the reliability of downloading artifacts for the SPDX and CycloneDx reports.