### PR TITLE
feat: add endpoint to create many templates at once.

### DIFF
--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -184,20 +184,15 @@ export class AdminAPI extends Controller {
       @Body() body: {templates: TemplateValues[]},
       @Request() req: express.Request
     ): Promise<TemplateResponse[]> {
-      // Generate ID here to audit before creating
-      const id = uniqueId();
-
       await audit(req, "template.create.many", "c", {
         target: {
-          id,
           fields: body,
         },
       });
 
       const templates: TemplateResponse[] = []
-
       body.templates.map(async (templateToCreate) => {
-        const template = await createTemplate(auth, projectId, environmentId, Object.assign(templateToCreate, { id }));
+        const template = await createTemplate(auth, projectId, environmentId, Object.assign(templateToCreate, { id: uniqueId() }));
         templates.push(template)
       })
       this.setStatus(201);

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -188,7 +188,7 @@ export class AdminAPI extends Controller {
         throw { status: 400, err: new Error("Can only create 100 templates at once.") };
       }
 
-      await audit(req, "template.create.many", "c", {
+      await audit(req, "template.create.bulk", "c", {
         target: {
           fields: body,
         },

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -194,11 +194,17 @@ export class AdminAPI extends Controller {
         },
       });
 
-      const templates: TemplateResponse[] = []
+      const templates: TemplateResponse[] = await Promise.all(
       body.templates.map(async (templateToCreate) => {
-        const template = await createTemplate(auth, projectId, environmentId, Object.assign(templateToCreate, { id: uniqueId() }));
-        templates.push(template)
+        const template = await createTemplate(
+          auth,
+          projectId,
+          environmentId,
+          Object.assign(templateToCreate, { id: uniqueId() })
+        );
+        return template;
       })
+    );
 
       this.setStatus(201);
       return templates;

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -175,7 +175,7 @@ export class AdminAPI extends Controller {
    * @param environmentId The environment id
    * @param body          The template resource to create
    */
-    @Post("project/{projectId}/templates")
+    @Post("project/{projectId}/templates/bulk")
     @SuccessResponse("201", "Created")
     public async createTemplates(
       @Header("Authorization") auth: string,

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -15,7 +15,7 @@ import {
 } from "tsoa";
 import express from "express";
 
-import { TemplateSearchResults, TemplateResponse, TemplateValues } from "../models/template";
+import { TemplateSearchResults, TemplateResponse, TemplateValues, responseFromTemplate } from "../models/template";
 import createTemplate from "../handlers/admin/createTemplate";
 import searchTemplates from "../handlers/admin/searchTemplates";
 import deleteTemplate from "../handlers/admin/deleteTemplate";
@@ -139,7 +139,7 @@ export class AdminAPI extends Controller {
    * @param environmentId The environment id
    * @param body          The template resource to create
    */
-  @Post("project/{projectId}/template")
+  @Post("project/{projectId}/templates")
   @SuccessResponse("201", "Created")
   public async createTemplate(
     @Header("Authorization") auth: string,
@@ -162,7 +162,7 @@ export class AdminAPI extends Controller {
 
     this.setStatus(201);
 
-    return template;
+    return template
   }
 
   /**
@@ -195,6 +195,7 @@ export class AdminAPI extends Controller {
         const template = await createTemplate(auth, projectId, environmentId, Object.assign(templateToCreate, { id: uniqueId() }));
         templates.push(template)
       })
+
       this.setStatus(201);
       return templates;
     }

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -15,7 +15,7 @@ import {
 } from "tsoa";
 import express from "express";
 
-import { TemplateSearchResults, TemplateResponse, TemplateValues, responseFromTemplate } from "../models/template";
+import { TemplateSearchResults, TemplateResponse, TemplateValues } from "../models/template";
 import createTemplate from "../handlers/admin/createTemplate";
 import searchTemplates from "../handlers/admin/searchTemplates";
 import deleteTemplate from "../handlers/admin/deleteTemplate";
@@ -184,6 +184,10 @@ export class AdminAPI extends Controller {
       @Body() body: {templates: TemplateValues[]},
       @Request() req: express.Request
     ): Promise<TemplateResponse[]> {
+      if (body.templates.length > 1000) {
+        throw { status: 400, err: new Error("Can only create 100 templates at once.") };
+      }
+
       await audit(req, "template.create.many", "c", {
         target: {
           fields: body,

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -184,7 +184,7 @@ export class AdminAPI extends Controller {
       @Body() body: {templates: TemplateValues[]},
       @Request() req: express.Request
     ): Promise<TemplateResponse[]> {
-      if (body.templates.length > 1000) {
+      if (body.templates.length > 100) {
         throw { status: 400, err: new Error("Can only create 100 templates at once.") };
       }
 
@@ -194,13 +194,16 @@ export class AdminAPI extends Controller {
         },
       });
 
+      await checkAdminAccessUnwrapped(auth, projectId);
+
       const templates: TemplateResponse[] = await Promise.all(
       body.templates.map(async (templateToCreate) => {
         const template = await createTemplate(
           auth,
           projectId,
           environmentId,
-          Object.assign(templateToCreate, { id: uniqueId() })
+          Object.assign(templateToCreate, { id: uniqueId() }),
+          true,
         );
         return template;
       })

--- a/src/handlers/admin/createTemplate.ts
+++ b/src/handlers/admin/createTemplate.ts
@@ -6,9 +6,12 @@ export default async function (
   auth: string,
   projectId: string,
   environmentId: string,
-  values: TemplateValues
+  values: TemplateValues,
+  isBulk?:boolean,
 ): Promise<TemplateResponse> {
-  await checkAdminAccessUnwrapped(auth, projectId);
+  if (!isBulk) {
+    await checkAdminAccessUnwrapped(auth, projectId);
+  }
 
   const template = await createTemplate({
     id: values.id,


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change
Adds a new endpoint that expects the following object:
```
{
    templates: TemplateValues[]
}
```

will create many templates to the same project and environment at once.

# Does your change fix a particular issue?

Not an issue. Will be used by my cal.com integration to setup a list of default templates for all events that cal.com will report.
