### PR TITLE
chore: Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   retraced:
 


### PR DESCRIPTION
# Fixes docker-compose.yaml: `version` is obsolete
