### PR TITLE
Resolve CVEs in busybox and ssl_client

### DIFF
--- a/deploy/Dockerfile-postgres
+++ b/deploy/Dockerfile-postgres
@@ -11,6 +11,8 @@ RUN apk add --update --no-cache \
     libgcrypt \
     ncurses-libs \
     ncurses-terminfo-base \
-    openssl
+    openssl \
+    busybox \
+    ssl_client
 
 VOLUME /var/run/postgresql


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

Resolving the following SVEs

```
[0007]  INFO ignoring 8 matches due to user-provided ignore rules
NAME        INSTALLED   FIXED-IN    TYPE  VULNERABILITY   SEVERITY 
busybox     1.35.0-r17  1.35.0-r18  apk   CVE-2023-42366  Medium    
ssl_client  1.35.0-r17  1.35.0-r18  apk   CVE-2023-42366  Medium
discovered vulnerabilities at or above the severity threshold
```

There is no updated postrges 10 base image at this time.

# Does your change fix a particular issue?

Fixes #(issue)
