### PR TITLE
chore: Update search methods to include 'received' field in search and sort criteria

### DIFF
--- a/src/handlers/graphql/search.ts
+++ b/src/handlers/graphql/search.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 
 import queryEvents, { Options } from "../../models/event/query";
-import filterEvents from "../../models/event/filter";
+import filterEvents, { Result } from "../../models/event/filter";
 import addDisplayTitles from "../../models/event/addDisplayTitles";
 import { Scope } from "../../security/scope";
 import getGroups from "../../models/group/gets";
@@ -46,6 +46,10 @@ export default async function search(q: any, args: Args, context: Scope) {
   }
 
   const results = await searcher(opts);
+  return await processEvents(context, results, opts);
+}
+
+async function processEvents(context: Scope, results: Result, opts: Options) {
   const events = await addDisplayTitles({
     projectId: context.projectId,
     environmentId: context.environmentId,
@@ -104,7 +108,7 @@ export default async function search(q: any, args: Args, context: Scope) {
 
     return {
       node: event,
-      cursor: encodeCursor(event.canonical_time, event.id),
+      cursor: encodeCursor(event.received, event.id),
     };
   });
 

--- a/src/models/event/filter.ts
+++ b/src/models/event/filter.ts
@@ -56,7 +56,7 @@ export default async function filter(opts: Options): Promise<Result> {
         SELECT doc
         FROM indexed_events
         WHERE ${wheres.join(" AND ")}
-        ORDER BY (doc-> 'received')::text::bigint ${_.toUpper(opts.sort)}, id ${_.toUpper(opts.sort)}
+        ORDER BY (doc-> 'received')::text::bigint ${_.toUpper(opts.sort)}, (doc-> 'canonical_time')::text::bigint ${_.toUpper(opts.sort)}, id ${_.toUpper(opts.sort)}
         LIMIT ${size}`;
 
   const results = await pgPool.query(q, vals as any);

--- a/src/models/event/filter.ts
+++ b/src/models/event/filter.ts
@@ -41,12 +41,12 @@ export default async function filter(opts: Options): Promise<Result> {
   if (opts.cursor) {
     if (opts.sort === "desc") {
       wheres.push(
-        `(((doc -> 'canonical_time')::text::bigint < ${nextParam()}) OR ((doc -> 'canonical_time')::text::bigint = ${nextParam()} AND id < ${nextParam()}))`
+        `(((doc -> 'received')::text::bigint < ${nextParam()}) OR ((doc -> 'received')::text::bigint = ${nextParam()} AND id < ${nextParam()}))`
       );
       vals.push(opts.cursor[0], opts.cursor[0], opts.cursor[1]);
     } else {
       wheres.push(
-        `(((doc -> 'canonical_time')::text::bigint > ${nextParam()}) OR ((doc -> 'canonical_time')::text::bigint = ${nextParam()} AND id > ${nextParam()}))`
+        `(((doc -> 'received')::text::bigint > ${nextParam()}) OR ((doc -> 'received')::text::bigint = ${nextParam()} AND id > ${nextParam()}))`
       );
       vals.push(opts.cursor[0]);
     }
@@ -56,7 +56,7 @@ export default async function filter(opts: Options): Promise<Result> {
         SELECT doc
         FROM indexed_events
         WHERE ${wheres.join(" AND ")}
-        ORDER BY (doc-> 'canonical_time')::text::bigint ${_.toUpper(opts.sort)}, id ${_.toUpper(opts.sort)}
+        ORDER BY (doc-> 'received')::text::bigint ${_.toUpper(opts.sort)}, id ${_.toUpper(opts.sort)}
         LIMIT ${size}`;
 
   const results = await pgPool.query(q, vals as any);

--- a/src/models/event/query.ts
+++ b/src/models/event/query.ts
@@ -303,7 +303,7 @@ export function searchParams(opts: Options): RequestParams.Search {
     size: opts.size !== 0 ? opts.size : undefined,
     body: {
       query: searchQuery,
-      sort: [{ received: opts.sort }],
+      sort: [{ received: opts.sort }, { canonical_time: opts.sort }],
     },
   };
 

--- a/src/models/event/query.ts
+++ b/src/models/event/query.ts
@@ -266,7 +266,7 @@ export function searchParams(opts: Options): RequestParams.Search {
       bool: {
         must_not: {
           range: {
-            canonical_time: {
+            received: {
               [isAsc ? "lt" : "gt"]: timestamp,
             },
           },
@@ -279,7 +279,7 @@ export function searchParams(opts: Options): RequestParams.Search {
           {
             // include non-identical timestamps in range
             range: {
-              canonical_time: {
+              received: {
                 [isAsc ? "gt" : "lt"]: timestamp,
               },
             },
@@ -303,7 +303,7 @@ export function searchParams(opts: Options): RequestParams.Search {
     size: opts.size !== 0 ? opts.size : undefined,
     body: {
       query: searchQuery,
-      sort: [{ canonical_time: opts.sort }],
+      sort: [{ received: opts.sort }],
     },
   };
 

--- a/src/test/models/event/query.ts
+++ b/src/test/models/event/query.ts
@@ -221,7 +221,7 @@ class QueryEventsTest {
             ],
           },
         },
-        sort: [{ received: "asc" }],
+        sort: [{ received: "asc" }, { canonical_time: "asc" }],
       },
     };
     assert.deepEqual(output, answer);

--- a/src/test/models/event/query.ts
+++ b/src/test/models/event/query.ts
@@ -191,7 +191,7 @@ class QueryEventsTest {
                 bool: {
                   must_not: {
                     range: {
-                      canonical_time: {
+                      received: {
                         lt: 1492060162148,
                       },
                     },
@@ -203,7 +203,7 @@ class QueryEventsTest {
                   should: [
                     {
                       range: {
-                        canonical_time: {
+                        received: {
                           gt: 1492060162148,
                         },
                       },
@@ -221,7 +221,7 @@ class QueryEventsTest {
             ],
           },
         },
-        sort: [{ canonical_time: "asc" }],
+        sort: [{ received: "asc" }],
       },
     };
     assert.deepEqual(output, answer);


### PR DESCRIPTION
Using `received` instead of `canonical_time` for sorting