### PR TITLE
chore: Update Elasticsearch image version to 7.17.22

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,7 +111,7 @@ services:
     restart: "always"
 
   elasticsearch:
-    image: elasticsearch:7.8.0
+    image: elasticsearch:7.17.22
     volumes:
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     ports:


### PR DESCRIPTION
Upgrades ElasticSearch version in docker-compose file
