### PR TITLE
feat: Add paginated GraphQL endpoint for viewer

### DIFF
--- a/integration/test/pkg/specs.ts
+++ b/integration/test/pkg/specs.ts
@@ -110,6 +110,13 @@ export const search = (q: string) => {
   };
 };
 
+export const searchPaginated = (q: string) => {
+  return {
+    variables: { query: q, pageLimit: 20, pageOffset: 0 },
+    query: GraphQLQueryPaginated.query,
+  };
+};
+
 export const GraphQLQuery = {
   variables: { query: "", last: 20, before: "" },
   query: `
@@ -119,6 +126,69 @@ export const GraphQLQuery = {
         pageInfo {
             hasPreviousPage
         }
+        edges {
+            cursor
+            node {
+                id
+                action
+                crud
+                created
+                received
+                canonical_time
+                description
+                actor {
+                    id
+                    name
+                    href
+                    fields {
+                        key
+                        value
+                    }
+                }
+                group {
+                    id
+                    name
+                }
+                target {
+                    id
+                    name
+                    href
+                    type
+                    fields {
+                        key
+                        value
+                    }
+                }
+                display {
+                    markdown
+                }
+                is_failure
+                is_anonymous
+                source_ip
+                country
+                loc_subdiv1
+                loc_subdiv2
+                fields {
+                    key
+                    value
+                }
+                external_id
+                metadata {
+                    key
+                    value
+                }
+            }
+        }
+    }
+}`,
+};
+
+export const GraphQLQueryPaginated = {
+  variables: { query: "", pageLimit: 20, pageOffset: 0 },
+  query: `
+    query SearchPaginated($query: String!, $pageOffset: Int!, $pageLimit: Int!, $startCursor: String, $sortOrder: sortOrder) {
+    searchPaginated(query: $query, pageOffset: $pageOffset, pageLimit: $pageLimit, startCursor: $startCursor, sortOrder: $sortOrder) {
+        totalCount
         edges {
             cursor
             node {

--- a/integration/test/viewer/searchpaginated.ts
+++ b/integration/test/viewer/searchpaginated.ts
@@ -1,0 +1,269 @@
+import * as querystring from "querystring";
+import { Client, CRUD } from "@retracedhq/retraced";
+import tv4 from "tv4";
+import "mocha";
+import { CreateEventSchema, searchPaginated } from "../pkg/specs";
+import { retracedUp } from "../pkg/retracedUp";
+import { sleep, isoDate } from "../pkg/util";
+import * as Env from "../env";
+import assert from "assert";
+import axios from "axios";
+
+const randomNumber = Math.floor(Math.random() * 99999) + 1;
+const currentTime = new Date();
+currentTime.setMilliseconds(0); // api only returns seconds precision
+
+describe("Viewer Paginated API", function () {
+  describe("Given the Retraced API is up and running", function () {
+    const groupID = "rtrccdqa" + randomNumber.toString();
+    const targetID = "rtrccdapi";
+    const actorID = "qa@retraced.io";
+
+    beforeEach(retracedUp(Env));
+
+    context("And a call is made into the Retraced API with a standard audit event", function () {
+      beforeEach(async function () {
+        const retraced = new Client({
+          apiKey: Env.ApiKey,
+          projectId: Env.ProjectID,
+          endpoint: Env.Endpoint,
+        });
+
+        const event = {
+          action: "integration.test.api." + randomNumber.toString(),
+          group: {
+            id: groupID,
+            name: "RetracedQA",
+          },
+          created: currentTime,
+          crud: "c" as CRUD,
+          source_ip: "192.168.0.1",
+          actor: {
+            id: actorID,
+            name: "RetracedQA Employee",
+            href: "https://retraced.io/employees/qa",
+            fields: {
+              department: "QA",
+            },
+          },
+          target: {
+            id: targetID,
+            name: "Retraced API",
+            href: "https://customertowne.xyz/records/rtrccdapi",
+            type: "integration",
+            fields: {
+              record_count: "100",
+            },
+          },
+          description: "Automated integration testing...",
+          is_failure: false,
+          fields: {
+            quality: "excellent",
+          },
+        };
+        const valid = tv4.validate(event, CreateEventSchema);
+        if (!valid) {
+          console.log(tv4.error);
+        }
+        assert.strictEqual(valid, true);
+        await retraced.reportEvent(event);
+      });
+
+      context("And a call is made to create a viewer description scoped to a target", function () {
+        let token;
+
+        beforeEach(async () => {
+          const opts = {
+            actor_id: actorID,
+            group_id: groupID,
+            target_id: targetID,
+          };
+          const qs = querystring.stringify(opts);
+          const resp1 = await axios.get(
+            `${Env.Endpoint}/publisher/v1/project/${Env.ProjectID}/viewertoken?${qs}`,
+            {
+              headers: {
+                Authorization: `Token token=${Env.ApiKey}`,
+              },
+            }
+          );
+          assert(resp1);
+          token = resp1.data.token;
+        });
+
+        context("And the viewer descriptor is exchanged for a session", function () {
+          let viewerSession;
+          beforeEach(async () => {
+            const resp2 = await axios.post(`${Env.Endpoint}/viewer/v1/viewersession`, { token });
+            assert(resp2);
+            assert.strictEqual(resp2.status, 200);
+            viewerSession = resp2.data.token;
+          });
+
+          context("When a call is made to the Viewer API GraphQL endpoint for the event", function () {
+            let responseBody;
+            beforeEach(async function () {
+              this.timeout(Env.EsIndexWaitMs * 2);
+              await sleep(Env.EsIndexWaitMs);
+
+              const resp3 = await axios.post(
+                `${Env.Endpoint}/viewer/v1/graphql/paginated`,
+                searchPaginated("integration.test.api." + randomNumber.toString()),
+                {
+                  headers: {
+                    Authorization: viewerSession,
+                  },
+                }
+              );
+              assert(resp3);
+              assert.strictEqual(resp3.status, 200);
+              responseBody = resp3.data;
+            });
+            specify("Then the response should contain the correct information about the event", function () {
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.action,
+                "integration.test.api." + randomNumber.toString()
+              );
+            });
+          });
+        });
+      });
+
+      context("And a call is made to create a viewer descriptor", function () {
+        let token;
+        beforeEach(async () => {
+          const retraced = new Client({
+            apiKey: Env.ApiKey,
+            projectId: Env.ProjectID,
+            endpoint: Env.Endpoint,
+          });
+
+          token = await retraced.getViewerToken(
+            "rtrccdqa" + randomNumber.toString(),
+            "qa@retraced.io",
+            false
+          );
+        });
+
+        context("And the viewer descriptor is exchanged for a session", function () {
+          let viewerSession;
+          beforeEach(async () => {
+            const resp4 = await axios.post(`${Env.Endpoint}/viewer/v1/viewersession`, { token });
+            assert(resp4);
+            assert.strictEqual(resp4.status, 200);
+            viewerSession = resp4.data.token;
+          });
+
+          context("When a call is made to the Viewer API GraphQL endpoint for the event", function () {
+            let responseBody;
+            beforeEach(async function () {
+              this.timeout(Env.EsIndexWaitMs * 2);
+              await sleep(Env.EsIndexWaitMs);
+
+              const resp5 = await axios.post(
+                `${Env.Endpoint}/viewer/v1/graphql/paginated`,
+                searchPaginated("integration.test.api." + randomNumber.toString()),
+                {
+                  headers: {
+                    Authorization: viewerSession,
+                  },
+                }
+              );
+              assert(resp5);
+              assert.strictEqual(resp5.status, 200);
+              responseBody = resp5.data;
+            });
+
+            specify("Then the response should contain the correct information about the event", function () {
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.action,
+                "integration.test.api." + randomNumber.toString()
+              );
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.created,
+                isoDate(currentTime)
+              );
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.description,
+                "Automated integration testing..."
+              );
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.group.id,
+                "rtrccdqa" + randomNumber.toString()
+              );
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.actor.fields[0].key,
+                "department"
+              );
+              assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.actor.fields[0].value, "QA");
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.target.fields[0].key,
+                "record_count"
+              );
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.target.fields[0].value,
+                "100"
+              );
+              assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.fields[0].key, "quality");
+              assert.strictEqual(
+                responseBody.data.searchPaginated.edges[0].node.fields[0].value,
+                "excellent"
+              );
+              assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.target.name, "Retraced API");
+              assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.is_failure, false);
+              assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.crud, "c");
+              assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.source_ip, "192.168.0.1");
+            });
+          });
+          context("When a second call is made to the Viewer API GraphQL endpoint", function () {
+            let responseBody;
+            beforeEach(async function () {
+              this.timeout(Env.EsIndexWaitMs * 2);
+              await sleep(Env.EsIndexWaitMs);
+
+              const resp6 = await axios.post(
+                `${Env.Endpoint}/viewer/v1/graphql/paginated`,
+                searchPaginated("audit.log.view"),
+                {
+                  headers: {
+                    Authorization: viewerSession,
+                  },
+                }
+              );
+              assert(resp6);
+              assert.strictEqual(resp6.status, 200);
+              responseBody = resp6.data;
+            });
+            specify(
+              "Then the most recent event should be an audit.log.view event with the actor specified",
+              function () {
+                assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.action, "audit.log.view");
+                assert.strictEqual(
+                  responseBody.data.searchPaginated.edges[0].node.group.id,
+                  "rtrccdqa" + randomNumber.toString()
+                );
+                assert.strictEqual(responseBody.data.searchPaginated.edges[0].node.crud, "r");
+                assert.strictEqual(
+                  responseBody.data.searchPaginated.edges[0].node.actor.id,
+                  "qa@retraced.io"
+                );
+                assert.strictEqual(
+                  responseBody.data.searchPaginated.edges[0].node.actor.name,
+                  "RetracedQA Employee"
+                );
+                assert.strictEqual(
+                  responseBody.data.searchPaginated.edges[0].node.actor.fields[0].key,
+                  "department"
+                );
+                assert.strictEqual(
+                  responseBody.data.searchPaginated.edges[0].node.actor.fields[0].value,
+                  "QA"
+                );
+              }
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/handlers/graphql/paginatedHandler.ts
+++ b/src/handlers/graphql/paginatedHandler.ts
@@ -1,0 +1,37 @@
+import { Scope } from "../../security/scope";
+import { validateQuery } from "./handler";
+import schema from "./schema";
+import { graphql } from "graphql";
+
+export default async function (req, context: Scope) {
+  const query = req.body.query || req.query.query;
+  const op = req.body.operationName || req.query.operationName;
+  const vars = req.body.variables || req.query.variables;
+  const errors = validateQuery(query, schema);
+  if (errors.length > 0) {
+    return {
+      status: 400,
+      body: JSON.stringify(errors),
+    };
+  }
+  const result = await graphql({
+    schema,
+    source: query,
+    rootValue: null,
+    contextValue: context,
+    variableValues: vars,
+    operationName: op,
+  });
+
+  if (result.errors) {
+    return {
+      status: 400,
+      body: JSON.stringify(result),
+    };
+  }
+
+  return {
+    status: 200,
+    body: JSON.stringify(result),
+  };
+}

--- a/src/handlers/graphql/schema.ts
+++ b/src/handlers/graphql/schema.ts
@@ -277,29 +277,31 @@ const pageInfoType = new GraphQLObjectType({
   },
 });
 
+const EventsList = new GraphQLList(
+  new GraphQLObjectType({
+    description: "The event and cursor for a single result.",
+    name: "SearchEventEdge",
+    fields: {
+      node: {
+        description: "The event object.",
+        type: eventType,
+      },
+      cursor: {
+        description:
+          "An opaque cursor for paginating from this point in the search results. Use it as the <code>after</code> argument to paginate forward or the <code>before</code> argument to paginate backward.",
+        type: GraphQLString,
+      },
+    },
+  })
+);
+
 const SearchQueryResult = new GraphQLObjectType({
   description: "The results of a search query.",
   name: "SearchQueryResult",
   fields: {
     edges: {
       description: "The events and cursors matching the query.",
-      type: new GraphQLList(
-        new GraphQLObjectType({
-          description: "The event and cursor for a single result.",
-          name: "SearchEventEdge",
-          fields: {
-            node: {
-              description: "The event object.",
-              type: eventType,
-            },
-            cursor: {
-              description:
-                "An opaque cursor for paginating from this point in the search results. Use it as the <code>after</code> argument to paginate forward or the <code>before</code> argument to paginate backward.",
-              type: GraphQLString,
-            },
-          },
-        })
-      ),
+      type: EventsList,
     },
     pageInfo: {
       description: "Indications that more search results are available.",
@@ -318,23 +320,7 @@ const PaginatedSearchQueryResult = new GraphQLObjectType({
   fields: {
     edges: {
       description: "The events and cursors matching the query.",
-      type: new GraphQLList(
-        new GraphQLObjectType({
-          description: "The event and cursor for a single result.",
-          name: "PaginatedSearchEventEdge",
-          fields: {
-            node: {
-              description: "The event object.",
-              type: eventType,
-            },
-            cursor: {
-              description:
-                "An opaque cursor for paginating from this point in the search results. Use it as the <code>after</code> argument to paginate forward or the <code>before</code> argument to paginate backward.",
-              type: GraphQLString,
-            },
-          },
-        })
-      ),
+      type: EventsList,
     },
     totalCount: {
       description: "The total number of search results matched by the query.",

--- a/src/handlers/graphql/search.ts
+++ b/src/handlers/graphql/search.ts
@@ -17,13 +17,6 @@ export interface Args {
   last?: number;
   before?: string;
 }
-export interface ArgsPaginated {
-  query: string;
-  page?: number;
-  pageSize: number;
-  sort?: "asc" | "desc";
-  cursor?: string;
-}
 
 export default async function search(q: any, args: Args, context: Scope) {
   if (args.first && args.last) {

--- a/src/handlers/viewer/viewerPaginatedGraphQL.ts
+++ b/src/handlers/viewer/viewerPaginatedGraphQL.ts
@@ -1,0 +1,44 @@
+import querystring from "querystring";
+import { checkViewerAccess } from "../../security/helpers";
+import { defaultEventCreater, CreateEventRequest } from "../createEvent";
+
+import paginatedHandler from "../graphql/paginatedHandler";
+
+export default async function (req) {
+  const claims = await checkViewerAccess(req);
+  const thisViewEvent: CreateEventRequest = {
+    created: new Date(),
+    action: claims.viewLogAction,
+    crud: "r",
+    actor: {
+      id: claims.actorId,
+    },
+    group: {
+      id: claims.groupId,
+    },
+    description: `Viewed the paginated audit log`,
+    source_ip: claims.ip,
+  };
+
+  let targetId;
+  if (claims.scope) {
+    const scope = querystring.parse(claims.scope);
+    targetId = scope.target_id;
+    thisViewEvent.target = {
+      id: targetId,
+    };
+  }
+
+  const results = await paginatedHandler(req, {
+    projectId: claims.projectId,
+    environmentId: claims.environmentId,
+    groupId: claims.groupId,
+    targetId,
+  });
+
+  if (!req.query.skipViewLogEvent) {
+    await defaultEventCreater.saveRawEvent(claims.projectId, claims.environmentId, thisViewEvent);
+  }
+
+  return results;
+}

--- a/src/models/event/filter.ts
+++ b/src/models/event/filter.ts
@@ -17,7 +17,7 @@ export interface OptionsPaginated {
   scope: Scope;
   sortOrder: "asc" | "desc";
   pageOffset: number;
-  startCursor?: [number, string];
+  startCursor?: [number, string, number];
   pageLimit: number;
 }
 

--- a/src/models/event/filter.ts
+++ b/src/models/event/filter.ts
@@ -12,6 +12,15 @@ export interface Options {
   cursor?: [number, string];
 }
 
+export interface OptionsPaginated {
+  query: string;
+  scope: Scope;
+  sortOrder: "asc" | "desc";
+  pageOffset: number;
+  startCursor?: [number, string];
+  pageLimit: number;
+}
+
 export interface Result {
   totalHits: any;
   events: any[];
@@ -57,6 +66,55 @@ export default async function filter(opts: Options): Promise<Result> {
         WHERE ${wheres.join(" AND ")}
         ORDER BY (doc-> 'canonical_time')::text::bigint ${_.toUpper(opts.sort)}, id ${_.toUpper(opts.sort)}
         LIMIT ${size}`;
+
+  const results = await pgPool.query(q, vals as any);
+  const events = results.rows ? results.rows.map((row) => row.doc) : [];
+
+  const countQ = `
+        SELECT COUNT(1)
+        FROM indexed_events
+        WHERE ${wheresForCountQ.join(" AND ")}`;
+  const count = await pgPool.query(countQ, valsForCountQ as any);
+  const totalHits = parseInt(count.rows[0].count, 10);
+
+  return {
+    events,
+    totalHits: { value: totalHits },
+  };
+}
+
+export async function filterEventsPaginated(opts: OptionsPaginated): Promise<Result> {
+  const query = _.isString(opts.query) ? parseQuery(opts.query) : opts.query;
+  const filters = getFilters(query, opts.scope);
+  const size = opts.pageLimit || defaultSize;
+  const wheres = filters.map(({ where }) => where);
+  const vals = _.flatten(filters.map(({ values }) => values));
+  // copies without cursor filters for total count
+  const wheresForCountQ = wheres.slice();
+  const valsForCountQ = vals.slice();
+  const nextParam = paramer(vals.length);
+
+  // Like ES, the cursor is a timestamp and id. The id is only used for events
+  // exactly matching the timestamp.
+  if (opts.startCursor) {
+    if (opts.sortOrder === "desc") {
+      wheres.push(
+        `(((doc -> 'canonical_time')::text::bigint < ${nextParam()}) OR ((doc -> 'canonical_time')::text::bigint = ${nextParam()} AND id <= ${nextParam()}))`
+      );
+    } else {
+      wheres.push(
+        `(((doc -> 'canonical_time')::text::bigint > ${nextParam()}) OR ((doc -> 'canonical_time')::text::bigint = ${nextParam()} AND id >= ${nextParam()}))`
+      );
+    }
+    vals.push(opts.startCursor[0], opts.startCursor[0], opts.startCursor[1]);
+  }
+
+  const q = `
+        SELECT doc
+        FROM indexed_events
+        WHERE ${wheres.join(" AND ")}
+        ORDER BY (doc-> 'canonical_time')::text::bigint ${_.toUpper(opts.sortOrder)}, id ${_.toUpper(opts.sortOrder)}
+        LIMIT ${size} offset ${opts.pageOffset}`;
 
   const results = await pgPool.query(q, vals as any);
   const events = results.rows ? results.rows.map((row) => row.doc) : [];

--- a/src/models/event/query.ts
+++ b/src/models/event/query.ts
@@ -25,7 +25,7 @@ export interface OptionsPaginated {
   scope: Scope;
   sortOrder: "asc" | "desc";
   pageOffset: number;
-  startCursor?: [number, string];
+  startCursor?: [number, string, number];
   pageLimit: number;
 }
 
@@ -56,10 +56,11 @@ export default async function query(opts: Options): Promise<Result> {
 export async function queryEventsPaginated(opts: OptionsPaginated): Promise<Result> {
   const result = await doQueryPaginated(opts);
 
-  delete opts.startCursor;
-  opts.pageLimit = 0;
-
-  const total = await doQueryPaginated(opts);
+  const total = await doQueryPaginated({
+    ...opts,
+    startCursor: undefined,
+    pageOffset: 0,
+  });
 
   return {
     totalHits: total.totalHits,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -40,6 +40,7 @@ import viewerCreateExport from "./handlers/viewer/createExport";
 import viewerSearchEvents from "./handlers/viewer/searchEvents";
 import viewerDeleteEitapiToken from "./handlers/viewer/deleteEitapiToken";
 import viewerGraphQL from "./handlers/viewer/graphql";
+import viewerPaginatedGraphQL from "./handlers/viewer/viewerPaginatedGraphQL";
 import viewerListEitapiTokens from "./handlers/viewer/listEitapiTokens";
 import viewerListExports from "./handlers/viewer/listExports";
 import viewerRenderSavedExport from "./handlers/viewer/renderSavedExport";
@@ -204,6 +205,11 @@ export default {
     path: "/viewer/v1/graphql",
     method: "post",
     handler: viewerGraphQL,
+  },
+  viewerGraphQLPaginated: {
+    path: "/viewer/v1/graphql/paginated",
+    method: "post",
+    handler: viewerPaginatedGraphQL,
   },
   viewerSearchEvents: {
     path: "/viewer/v1/project/:projectId/events/search",

--- a/src/test/handlers/graphql.ts
+++ b/src/test/handlers/graphql.ts
@@ -65,7 +65,7 @@ export class GraphqlTest {
     const errors = validateQuery(query, schema);
     let r = assert(errors);
     r = assert.strictEqual(
-      String(errors[0]).includes("Error: Duplicate field EventsConnection:totalCount."),
+      String(errors[0]).includes("Error: Duplicate field SearchQueryResult:totalCount."),
       true
     );
     return r;
@@ -79,7 +79,7 @@ export class GraphqlTest {
     const errors = validateQuery(query, schema);
     let r = assert(errors);
     r = assert.strictEqual(
-      String(errors[0]).includes("Error: Duplicate field EventsConnection:totalCount."),
+      String(errors[0]).includes("Error: Duplicate field SearchQueryResult:totalCount."),
       true
     );
     return r;


### PR DESCRIPTION
This commit adds a new GraphQL endpoint for the viewer that supports pagination. The new endpoint is located at `/viewer/v1/graphql/paginated` and is handled by the `viewerPaginatedGraphQL` function. This allows the viewer to retrieve paginated data from the GraphQL API.
