### PR TITLE
Added changes to convert date format in the Export functionality

### DIFF
--- a/src/models/saved_export/render.ts
+++ b/src/models/saved_export/render.ts
@@ -172,6 +172,9 @@ async function renderAsCSV(events) {
         }
       }
       const result = Object.assign({}, ev, flatActor, flatObject);
+      result.created = unixToIso(result.created);
+      result.received = unixToIso(result.received);
+      result.canonical_time = unixToIso(result.canonical_time);
       delete result.actor;
       delete result.object;
       delete result.object_id;
@@ -183,6 +186,11 @@ async function renderAsCSV(events) {
   });
 
   return await processing;
+}
+
+function unixToIso(unixTimestamp: number) {
+  const date = new Date(unixTimestamp);
+  return date.toISOString().slice(0, 19).replace('T', ' ');
 }
 
 function filterOptions(scope: Scope, qd: QueryDescriptor): FilterOptions {

--- a/src/models/saved_export/render.ts
+++ b/src/models/saved_export/render.ts
@@ -190,7 +190,7 @@ async function renderAsCSV(events) {
 
 function unixToIso(unixTimestamp: number) {
   const date = new Date(unixTimestamp);
-  return date.toISOString().slice(0, 19).replace('T', ' ');
+  return date.toISOString().slice(0, 19).replace("T", " ");
 }
 
 function filterOptions(scope: Scope, qd: QueryDescriptor): FilterOptions {

--- a/src/models/saved_export/render.ts
+++ b/src/models/saved_export/render.ts
@@ -189,6 +189,9 @@ async function renderAsCSV(events) {
 }
 
 function unixToIso(unixTimestamp: number) {
+  if(typeof unixTimestamp !== 'number' || !Number.isInteger(unixTimestamp)) {
+    throw new Error(`Invalid UNIX Timestamp - ${unixTimestamp}`)
+  }
   const date = new Date(unixTimestamp);
   return date.toISOString().slice(0, 19).replace("T", " ");
 }

--- a/src/models/saved_export/render.ts
+++ b/src/models/saved_export/render.ts
@@ -189,8 +189,8 @@ async function renderAsCSV(events) {
 }
 
 function unixToIso(unixTimestamp: number) {
-  if(typeof unixTimestamp !== 'number' || !Number.isInteger(unixTimestamp)) {
-    throw new Error(`Invalid UNIX Timestamp - ${unixTimestamp}`)
+  if (typeof unixTimestamp !== "number" || !Number.isInteger(unixTimestamp)) {
+    return null;
   }
   const date = new Date(unixTimestamp);
   return date.toISOString().slice(0, 19).replace("T", " ");


### PR DESCRIPTION
## Added change in the Export functionality:
 - Date Format change from UNIX timestamp to Human readable for the CSV exports
 - New function added in `render.ts` for the conversion.
 - The time output would of the format: "YYYY-MM-DD HH:MM:SS"
 
 ## Does your change fix a particular issue?
- Improves the readability of the exported logs

