### PR TITLE
Update deps, CVE ignore lists

### DIFF
--- a/.circleci/.anchore/grype.yaml
+++ b/.circleci/.anchore/grype.yaml
@@ -43,5 +43,20 @@ ignore:
   - vulnerability: CVE-2021-3393
     package:
       name: postgresql
+  # https://www.postgresql.org/support/security/CVE-2024-10979/
+  # Incorrect control of environment variables in PostgreSQL PL/Perl allows an unprivileged database user to
+  # change sensitive process environment variables (e.g. PATH). That often suffices to enable arbitrary code execution,
+  # even if the attacker lacks a database server operating system user.
+  - vulnerability: CVE-2024-10979
+    package:
+      name: postgresql
 
-
+  # https://www.postgresql.org/support/security/CVE-2025-1094/
+  # Improper neutralization of quoting syntax in PostgreSQL libpq functions PQescapeLiteral(), PQescapeIdentifier(), PQescapeString(), and PQescapeStringConn()
+  # allows a database input provider to achieve SQL injection in certain usage patterns. Specifically, SQL injection requires the application to use the
+  # function result to construct input to psql, the PostgreSQL interactive terminal. Similarly, improper neutralization of quoting syntax in PostgreSQL
+  # command line utility programs allows a source of command line arguments to achieve SQL injection when client_encoding is BIG5 and server_encoding is
+  # one of EUC_TW or MULE_INTERNAL
+  - vulnerability: CVE-2025-1094
+    package:
+      name: postgresql

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ scan-postgres: IMAGE=registry.replicated.com/library/retraced-postgres:local
 scan-postgres: DOCKERFILE=./deploy/Dockerfile-postgres
 scan-postgres: grype
 	docker build --pull -t ${IMAGE} -f ${DOCKERFILE} .
-	./grype --fail-on=medium --only-fixed -vv ${IMAGE}
+	./grype --fail-on=medium --only-fixed --config=.circleci/.anchore/grype.yaml  -vv ${IMAGE}
 
 scan-api: IMAGE=registry.replicated.com/library/retraced:local
 scan-api: DOCKERFILE=./deploy/Dockerfile-slim

--- a/deploy/Dockerfile-nsq
+++ b/deploy/Dockerfile-nsq
@@ -2,7 +2,7 @@ FROM nsqio/nsq:v1.0.0-compat
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     \
     \
   && apt-get clean \

--- a/deploy/Dockerfile-postgres
+++ b/deploy/Dockerfile-postgres
@@ -3,8 +3,6 @@ FROM postgres:10.23-alpine
 RUN apk add --update --no-cache \
     ca-certificates \
   && apk add --upgrade --no-cache \
-    \
-    \
     apk-tools \
     krb5-libs \
     libcom_err \
@@ -13,6 +11,7 @@ RUN apk add --update --no-cache \
     ncurses-terminfo-base \
     openssl \
     busybox \
-    ssl_client
+    ssl_client \
+  && apk upgrade --no-cache
 
 VOLUME /var/run/postgresql

--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -53,7 +53,7 @@ RUN make pkg SKIP=${skip_pkg}
 # curl must be included for cron
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     \


### PR DESCRIPTION
Thank you for contributing to Retraced!

- Added ignore lists for postgres
- Added upgrade commands for libc CVEs in bookworm, increasing API image size from 416MB to 434MB.

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)
