### PR TITLE
update to a debian/trixie base image

### DIFF
--- a/.circleci/.anchore/grype.yaml
+++ b/.circleci/.anchore/grype.yaml
@@ -93,3 +93,18 @@ ignore:
   - vulnerability: CVE-2025-8713
     package:
       name: postgresql
+
+  # https://www.postgresql.org/support/security/CVE-2025-12818/
+  # Integer wraparound in PostgreSQL libpq client library functions allows an application input provider or network peer to
+  # trigger memory allocation errors, causing libpq to allocate insufficient memory and leading to out-of-bounds writes and
+  # application crashes.
+  - vulnerability: CVE-2025-12818
+    package:
+      name: postgresql
+
+  # https://www.postgresql.org/support/security/CVE-2025-12817/
+  # Missing authorization check in CREATE STATISTICS command allows a table owner to create statistics in any schema without
+  # proper CREATE privileges, potentially causing denial of service for legitimate users.
+  - vulnerability: CVE-2025-12817
+    package:
+      name: postgresql

--- a/deploy/Dockerfile-nsq
+++ b/deploy/Dockerfile-nsq
@@ -1,6 +1,6 @@
 FROM nsqio/nsq:v1.0.0-compat
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     \

--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -1,7 +1,7 @@
 # # #
 # Cron build
 #
-FROM debian:bookworm-slim as cron
+FROM debian:trixie-slim as cron
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -51,7 +51,7 @@ RUN make pkg SKIP=${skip_pkg}
 # Main build
 #
 # curl must be included for cron
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
Thank you for contributing to Retraced!

# Please add a summary of your change

This updates NSQ and the main API container to use a debian trixie base image instead of debian bookworm.

# Does your change fix a particular issue?

Fixes #(issue)
