### PR TITLE
Replace hand-rolled IP regex with net.isIP()

### DIFF
--- a/src/handlers/createEvent.ts
+++ b/src/handlers/createEvent.ts
@@ -1,5 +1,6 @@
 import * as _ from "lodash";
 import * as moment from "moment";
+import { isIP } from "net";
 import * as pg from "pg";
 import * as pgFormat from "pg-format";
 import * as util from "util";
@@ -14,9 +15,6 @@ import { NSQClient } from "../persistence/nsq";
 import getPgPool, { Querier } from "../persistence/pg";
 import Authenticator from "../security/Authenticator";
 import { logger } from "../logger";
-
-const IPV4_REGEX = /^(?!0)(?!.*\.$)((1?\d?\d|25[0-5]|2[0-4]\d)(\.|$)){4}$/;
-const IPV6_REGEX = /^((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4}))*::((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4}))*|((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4})){7}$/;
 
 const requiredFields = [
   "action",
@@ -510,7 +508,7 @@ export class EventCreater {
       });
     }
 
-    if (maybeEvent.source_ip && !IPV4_REGEX.test(maybeEvent.source_ip) && !IPV6_REGEX.test(maybeEvent.source_ip)) {
+    if (maybeEvent.source_ip && isIP(maybeEvent.source_ip) === 0) {
       violations.push({
         message: `Unable to parse 'source_ip' field as valid IPV4 or IPV6 address: ${maybeEvent["source_ip"]}`,
         field: "source_ip",

--- a/src/test/handlers/createEvent.ts
+++ b/src/test/handlers/createEvent.ts
@@ -292,6 +292,60 @@ import { Connection } from "./Connection";
         expect(created.hash).to.equal("fake-hash");
     }
 
+    @test public async "EventCreater#createEvent() ipv6 shortened"() {
+        const pool = TypeMoq.Mock.ofType(pg.Pool);
+        const conn = TypeMoq.Mock.ofType(Connection);
+        const nsq = TypeMoq.Mock.ofType(NSQClient);
+        const authenticator = TypeMoq.Mock.ofType(Authenticator);
+        const fakeHasher = (e) => "fake-hash";
+        const fakeUUID = () => "kfbr392";
+
+        const body: CreateEventRequest = {
+            action: "largeTazoTea.purchase",
+            crud: "c",
+            actor: {
+                id: "vicki@vickstelmo.music",
+            },
+            source_ip: "2600:1900:0:2107::",
+        };
+
+        authenticator.setup((x) => x.getApiTokenOr401("token=some-token", "a-project"))
+            .returns(() => Promise.resolve({
+                token: "some-token",
+                created: moment(),
+                name: "A Token",
+                disabled: false,
+                projectId: "a-project",
+                environmentId: "an-environment",
+            }));
+
+        conn.setup((x) => x.release()).verifiable(TypeMoq.Times.once());
+        conn.setup((x) => x.query(EventCreater.insertIntoIngestTask, TypeMoq.It.isAny())) // Still need to validate args
+            .verifiable(TypeMoq.Times.once());
+        pool.setup((x) => x.connect()).returns(() => Promise.resolve(conn.object) as Promise<any> ).verifiable(TypeMoq.Times.once());
+
+        // set up nsq
+        const jobBody = JSON.stringify({ taskId: "kfbr392" });
+        nsq
+            .setup((x) => x.produce("raw_events", jobBody))
+            .returns((args) => Promise.resolve());
+
+        const creater = new EventCreater(
+            pool.object,
+            nsq.object,
+            fakeHasher,
+            fakeUUID,
+            authenticator.object,
+            50,
+            1000,
+        );
+
+        const created: CreateEventResponse = await creater.createEvent("token=some-token", "a-project", body);
+
+        expect(created.id).to.equal("kfbr392");
+        expect(created.hash).to.equal("fake-hash");
+    }
+
     @test public async "EventCreater#createEventsBulk()"() {
         const pool = TypeMoq.Mock.ofType(pg.Pool);
         const conn = TypeMoq.Mock.ofType(Connection);


### PR DESCRIPTION
# Please add a summary of your change

The custom IPV4_REGEX and IPV6_REGEX patterns were fragile and rejected valid shortened IPv6 addresses like "2600:1900:0:2107::". Using Node's built-in net.isIP() function properly handles all valid IPv4 and IPv6 formats.

Added test case for shortened IPv6 address format to guard against regression.

# Does your change fix a particular issue?
