### PR TITLE
Fix "Invalid date" for received/canonical_time in audit log GraphQL API

### DIFF
--- a/src/_processor/workers/NormalizeRepairer.ts
+++ b/src/_processor/workers/NormalizeRepairer.ts
@@ -24,8 +24,8 @@ export default class NormalizeRepairer {
     public static readonly selectFromIngestTask = `
     SELECT
            id,
-           extract(epoch from received) * 1000 as received_ms,
-           (extract(epoch from CURRENT_TIMESTAMP) - extract(epoch from received)) * 1000 as age_ms
+           (extract(epoch from received) * 1000)::double precision as received_ms,
+           ((extract(epoch from CURRENT_TIMESTAMP) - extract(epoch from received)) * 1000)::double precision as age_ms
     FROM ingest_task
     WHERE normalized_event IS NULL
       AND (extract(epoch from CURRENT_TIMESTAMP) - extract(epoch from received)) * 1000 > $1

--- a/src/_processor/workers/normalizeEvent.ts
+++ b/src/_processor/workers/normalizeEvent.ts
@@ -20,7 +20,7 @@ export default async function normalizeEvent(job) {
   try {
     const fields = `id, original_event, normalized_event, saved_to_dynamo, saved_to_postgres,
       saved_to_elasticsearch, project_id, environment_id, new_event_id,
-      extract(epoch from received) * 1000 as received`;
+      (extract(epoch from received) * 1000)::double precision as received`;
     const pgResp = await pg.query(`select ${fields} from ingest_task where id = $1`, [taskId]);
     if (!pgResp.rows.length) {
       throw new Error(`Couldn't find ingestion task with id '${taskId}'`);
@@ -139,7 +139,10 @@ function processEvent(origEvent, received, group, actor, target, locInfo, newEve
   ]);
 
   result.id = newEventId;
-  result.received = received;
+  // `received` may come back as a numeric string from Postgres (e.g. when EXTRACT() returns
+  // `numeric` instead of `double precision`, as on PG14+) - coerce defensively so downstream
+  // consumers (canonical_time fallback, JSON storage, later formatting) always see a Number.
+  result.received = Number(received);
   result.raw = JSON.stringify(origEvent);
 
   if (_.isEmpty(result.source_ip)) {

--- a/src/handlers/graphql/schema.ts
+++ b/src/handlers/graphql/schema.ts
@@ -182,19 +182,24 @@ const eventType = new GraphQLObjectType({
     received: {
       type: GraphQLString,
       description: "The time that the Retraced API received this event.",
-      resolve: ({ received }) => received && moment.utc(received).format(),
+      // received may be a numeric string (e.g. previously-stored events written before the
+      // EXTRACT()-returns-numeric fix, or any other source that doesn't hand back a Number) -
+      // coerce before formatting so moment doesn't fall back to its (broken) string parser.
+      resolve: ({ received }) => received && moment.utc(Number(received)).format(),
     },
 
     created: {
       type: GraphQLString,
       description: "The time that this event was reported as performed.",
-      resolve: ({ created }) => created && moment.utc(created).format(),
+      resolve: ({ created }) => created && moment.utc(Number(created)).format(),
     },
 
     canonical_time: {
       type: GraphQLString,
       description: "The created time if specified; else the received time.",
-      resolve: ({ canonical_time }) => canonical_time && moment.utc(canonical_time).format(),
+      // canonical_time falls back to `received` for events with no client-supplied `created`,
+      // so it can inherit the same numeric-string shape - same coercion applies here.
+      resolve: ({ canonical_time }) => canonical_time && moment.utc(Number(canonical_time)).format(),
     },
 
     is_failure: {

--- a/src/test/handlers/graphqlEventDateFields.ts
+++ b/src/test/handlers/graphqlEventDateFields.ts
@@ -1,0 +1,43 @@
+import { suite, test } from "mocha-typescript";
+import { expect } from "chai";
+import { GraphQLObjectType } from "graphql";
+import schema from "../../handlers/graphql/schema";
+
+function resolveEventField(fieldName: string, source: any) {
+  const eventType = schema.getType("Event") as GraphQLObjectType;
+  const field = eventType.getFields()[fieldName];
+  return (field.resolve as any)(source, {}, {}, {});
+}
+
+// Regression test for the "Invalid date" bug: on Postgres 14+, EXTRACT() returns `numeric`
+// instead of `double precision`, and the Postgres client returns `numeric` columns as
+// fixed-scale decimal strings (e.g. "1716818433375.000000") rather than numbers. Passing
+// that string straight into moment.utc() produces "Invalid date". received/created/
+// canonical_time must coerce to Number before formatting so both numeric-string and
+// plain-number inputs resolve to the same timestamp.
+@suite class GraphqlEventDateFieldsTest {
+  @test public "received: numeric-string epoch (Postgres 14+ shape) formats correctly, not Invalid date"() {
+    const formatted = resolveEventField("received", { received: "1716818433375.000000" });
+    expect(formatted).to.equal("2024-05-27T14:00:33Z");
+  }
+
+  @test public "received: plain-number epoch (pre-fix / Postgres <14 shape) still formats correctly"() {
+    const formatted = resolveEventField("received", { received: 1716818433375 });
+    expect(formatted).to.equal("2024-05-27T14:00:33Z");
+  }
+
+  @test public "canonical_time: inherits the same numeric-string shape via the received fallback"() {
+    const formatted = resolveEventField("canonical_time", { canonical_time: "1716818433375.000000" });
+    expect(formatted).to.equal("2024-05-27T14:00:33Z");
+  }
+
+  @test public "created: numeric-string epoch also formats correctly"() {
+    const formatted = resolveEventField("created", { created: "1716818433375.000000" });
+    expect(formatted).to.equal("2024-05-27T14:00:33Z");
+  }
+
+  @test public "received: falsy input is not formatted"() {
+    expect(resolveEventField("received", { received: null })).to.equal(null);
+    expect(resolveEventField("received", {})).to.equal(undefined);
+  }
+}


### PR DESCRIPTION
## Summary

`received` renders as `"Invalid date"` in the GraphQL API instead of a timestamp. `canonical_time` inherits the same bug on events with no `created` (it falls back to `received`).

## Root cause

`received` is computed via `extract(epoch from received) * 1000`. PostgreSQL 14 changed `EXTRACT()`'s return type from `double precision` to `numeric` ([PG14 release notes](https://www.postgresql.org/docs/14/release-14.html): *"Change EXTRACT() to return numeric, not double precision"*), and the Postgres client returns `numeric` as a string (e.g. `"1716818433375.000000"`) instead of a number, to avoid float rounding. `moment.utc()` on that string produces `"Invalid date"`.

Confirmed with `postgres:13` vs `postgres:14` in Docker, same query/client/format call:

| PG version | Type | Value | `moment.utc().format()` |
|---|---|---|---|
| 13 | `double precision` | `1715882054153` | `2024-05-16T17:54:14Z` |
| 14 | `numeric` | `"1715882054153.000000"` | `Invalid date` |

## Changes

- Cast to `::double precision` in `normalizeEvent.ts` / `NormalizeRepairer.ts` — fixes at the source.
- Coerce with `Number()` before `moment.utc()` in the `received`/`created`/`canonical_time` resolvers — also fixes already-stored events on read, no backfill needed.
- Added a regression test covering all three resolvers; verified it fails without the fix and passes with it.

## Testing

Full suite passes (50/50) via Node 20 in Docker.
