### PR TITLE
chore: add local docker compose setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean prebuild deps lint swagger routes build cover test report-coverage pkg build run run-processor run-debug
+.PHONY: clean prebuild deps lint swagger routes build cover test report-coverage pkg build run run-processor run-debug compose-up-build compose-up compose-down compose-reset compose-ps
 SKIP :=
 REPO := retracedhq/api
 SHELL := /bin/bash -lo pipefail
@@ -41,7 +41,7 @@ report-coverage:
 # and we need to change it to `require('./some-module')` to make `pkg` work, because pkg can't currently
 # handle imports that are not string literals.
 # sed -i.bak 's/lazyLoad(.\(.\+\).\, opts)/require(".\/api\/\1.js")/g' node_modules/@elastic/elasticsearch/api/index.js &&
-# 	sed -i.bak 's/function ESAPI/const path = require("path");\nfunction ESAPI/g' node_modules/@elastic/elasticsearch/api/index.js && cat node_modules/@elastic/elasticsearch/api/index.js && 
+# 	sed -i.bak 's/function ESAPI/const path = require("path");\nfunction ESAPI/g' node_modules/@elastic/elasticsearch/api/index.js && cat node_modules/@elastic/elasticsearch/api/index.js &&
 pkg:
 	if [ -n "$(SKIP)" ]; then exit 0; else \
 	 sed -i.bak "s/__dirname + '/'.\//g" node_modules/pg-format/lib/index.js && \
@@ -88,3 +88,20 @@ k8s-migrate:
 
 k8s: k8s-pre k8s-deployment k8s-service k8s-ingress k8s-migrate
 	: "Templated k8s yamls"
+
+# Local dev environment, see docker-compose.yml
+compose-up-build:
+	docker compose up -d --build
+
+compose-up:
+	docker compose up -d
+
+compose-down:
+	docker compose down
+
+# Also drops volumes, for a clean db/search index
+compose-reset:
+	docker compose down -v
+
+compose-ps:
+	docker compose ps -a

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Key responsibilities of the retraced API include:
 If there's a relevant clubhouse story, include `chXXX` with the story ID
 in your pull request.
 
+## Prerequisites
+
+- Docker with Compose v2
+- `curl` and `jq`, for the smoke-test commands below
+
 ## Usage
 #### Install deps
 > `yarn`
@@ -26,13 +31,39 @@ in your pull request.
 #### Run tests
 > `yarn test`
 
-#### Running with [Composer](https://github.com/retracedhq/composer)
+#### Running with Docker Compose
 
-> `docker-compose -f ../composer/docker-compose.yml up api`
+Builds retraced from source and runs the full stack (postgres, elasticsearch,
+nsqd, api, processor, cron), pre-seeded with a bootstrapped project/environment/API
+key. See `docker-compose.yml`'s header comment for connection details.
 
-#### Running with Skaffold
+> `make compose-up-build`
 
-> `skaffold dev -f skaffold.yaml`
+Other targets: `compose-up` (start without rebuilding), `compose-down`,
+`compose-reset` (also drops volumes, for a clean db/search index), `compose-ps`
+(check container status).
+
+#### Smoke-testing the dev env
+
+Once `compose-up-build` is healthy, send an event and read it back:
+
+```sh
+curl -s -X POST http://localhost:3000/publisher/v1/project/local-dev-project-id/event \
+  -H "Authorization: token=local-dev-api-token" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"test.event","crud":"c","is_anonymous":true}'
+```
+
+Wait a couple seconds for the processor to normalize/index it, then:
+
+```sh
+curl -s -X POST http://localhost:3000/publisher/v1/project/local-dev-project-id/graphql \
+  -H "Authorization: token=local-dev-api-token" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query { search(last: 5) { totalCount edges { node { id action crud received canonical_time } } } }"}' | jq .
+```
+
+A successful create returns `{"id": ..., "hash": ...}`, and the event should show up in the search results.
 
 ## Swagger Documentation
 
@@ -57,7 +88,7 @@ The outputs will be written to build/swagger.json
 
 The first time you generate markup, you will need to `make markup-deps` to install tooling.
 
-Then you can 
+Then you can
 
 ```
 make markup-docs

--- a/deploy/Dockerfile-postgres
+++ b/deploy/Dockerfile-postgres
@@ -1,4 +1,4 @@
-FROM postgres:10.15-alpine
+FROM postgres:14.22-alpine
 
 RUN apk add --update \
     ca-certificates \

--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -33,7 +33,7 @@ ADD Makefile /src
 RUN yarn install --force
 ADD .snyk /src
 ENV SNYK_TOKEN=${snyk_token}
-RUN npm run snyk-protect
+RUN if [ -n "${SNYK_TOKEN}" ]; then npm run snyk-protect; fi
 
 ADD . /src
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@
 
 services:
   postgres:
-    image: postgres:14-alpine
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-postgres
     container_name: retraced-postgres
     environment:
       POSTGRES_USER: retraced

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,190 @@
+# Runs the full Retraced stack locally, building images from source.
+# Usage:
+#   docker compose up --build
+#
+# Once healthy, the API is available at http://localhost:3000
+# and is pre-seeded (by the bootstrap/display-templates services) with:
+#   projectId:     local-dev-project-id
+#   environmentId: local-dev-environment-id
+#   apiKey:        local-dev-api-token
+
+services:
+  postgres:
+    image: postgres:14-alpine
+    container_name: retraced-postgres
+    environment:
+      POSTGRES_USER: retraced
+      POSTGRES_PASSWORD: retraced
+      POSTGRES_DB: retraced
+    volumes:
+      - retraced-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U retraced -d retraced"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  nsqd:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-nsq
+    container_name: retraced-nsqd
+    command: ["/bin/sh", "-c", "nsqd"]
+    ports:
+      - "4150:4150"
+      - "4151:4151"
+
+  elasticsearch:
+    image: elasticsearch:7.8.0
+    container_name: retraced-elasticsearch
+    environment:
+      discovery.type: single-node
+      http.host: "0.0.0.0"
+    ports:
+      - "9200:9200"
+    volumes:
+      - retraced-es-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  pg-migrate:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-slim
+    platform: linux/amd64
+    container_name: retraced-pg-migrate
+    command: ["/src/replicated-auditlog-migrations", "pg"]
+    environment:
+      POSTGRES_USER: retraced
+      POSTGRES_PASSWORD: retraced
+      POSTGRES_DATABASE: retraced
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      SCHEMA_PATH: /src/migrations/pg10
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  es-migrate:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-slim
+    platform: linux/amd64
+    container_name: retraced-es-migrate
+    command: ["/src/replicated-auditlog-migrations", "es"]
+    environment:
+      POSTGRES_USER: retraced
+      POSTGRES_PASSWORD: retraced
+      POSTGRES_DATABASE: retraced
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      ELASTICSEARCH_NODES: http://elasticsearch:9200
+    depends_on:
+      pg-migrate:
+        condition: service_completed_successfully
+      elasticsearch:
+        condition: service_healthy
+
+  api:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-slim
+    platform: linux/amd64
+    container_name: retraced-api
+    command: ["/src/replicated-auditlog-api"]
+    ports:
+      - "3000:3000"
+    environment:
+      POSTGRES_USER: retraced
+      POSTGRES_PASSWORD: retraced
+      POSTGRES_DATABASE: retraced
+      ELASTICSEARCH_NODES: http://elasticsearch:9200
+      RETRACED_API_BASE: ""
+      HMAC_SECRET_ADMIN: local-dev-hmac-admin-secret
+      HMAC_SECRET_VIEWER: local-dev-hmac-viewer-secret
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      NSQD_HOST: nsqd
+      NSQD_TCP_PORT: "4150"
+      NSQD_HTTP_PORT: "4151"
+    depends_on:
+      es-migrate:
+        condition: service_completed_successfully
+      nsqd:
+        condition: service_started
+
+  processor:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-slim
+    platform: linux/amd64
+    container_name: retraced-processor
+    command: ["/src/replicated-auditlog-processor"]
+    environment:
+      TMPDIR: /tmp
+      POSTGRES_USER: retraced
+      POSTGRES_PASSWORD: retraced
+      POSTGRES_DATABASE: retraced
+      ELASTICSEARCH_NODES: http://elasticsearch:9200
+      NO_WARP_PIPE: "1"
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      NSQD_HOST: nsqd
+      NSQD_TCP_PORT: "4150"
+      NSQD_HTTP_PORT: "4151"
+    depends_on:
+      es-migrate:
+        condition: service_completed_successfully
+      nsqd:
+        condition: service_started
+
+  cron:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-slim
+    platform: linux/amd64
+    container_name: retraced-cron
+    command: ["/usr/local/bin/replicated-auditlog-cron", "/crontab"]
+    environment:
+      RETRACED_DISABLE_GEOSYNC: "1"
+      NSQD_HOST: nsqd
+      NSQD_TCP_PORT: "4150"
+      NSQD_HTTP_PORT: "4151"
+    depends_on:
+      nsqd:
+        condition: service_started
+
+  bootstrap:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile-slim
+    platform: linux/amd64
+    container_name: retraced-bootstrap
+    command:
+      - /src/replicated-auditlog-retracedctl
+      - bootstrap
+      - --projectName
+      - "Local Dev Project"
+      - --projectId
+      - "local-dev-project-id"
+      - --environmentId
+      - "local-dev-environment-id"
+      - --apiKey
+      - "local-dev-api-token"
+    environment:
+      POSTGRES_USER: retraced
+      POSTGRES_PASSWORD: retraced
+      POSTGRES_DATABASE: retraced
+      ELASTICSEARCH_NODES: http://elasticsearch:9200
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+    depends_on:
+      es-migrate:
+        condition: service_completed_successfully
+
+volumes:
+  retraced-postgres-data:
+  retraced-es-data:

--- a/src/_db/commands/up/es.ts
+++ b/src/_db/commands/up/es.ts
@@ -33,11 +33,10 @@ export const builder = {
   postgresPassword: {
     demand: true,
   },
+  schemaPath: {
+    default: "/src/migrations/es",
+  },
 };
-
-function getSchemaPath() {
-  return path.join(__dirname, "../../../../migrations/es");
-}
 
 export const handler = (argv) => {
   const es = getElasticsearch();
@@ -56,7 +55,7 @@ export const handler = (argv) => {
       process.exit(1);
     }
 
-    const walker = walk.walk(getSchemaPath(), {
+    const walker = walk.walk(argv.schemaPath, {
       followLinks: false,
     });
 
@@ -84,7 +83,7 @@ export const handler = (argv) => {
           }
 
           return new Promise<any>((resolve, reject) => {
-            const esQuery = require(path.join(getSchemaPath(), stat.name))();
+            const esQuery = require(path.join(argv.schemaPath, stat.name))();
             switch (esQuery.category) {
               default:
                 reject(new Error("Unknown category"));


### PR DESCRIPTION
## Please add a summary of your change

- Add `docker-compose.yml`: runs the full stack from source (postgres, elasticsearch, nsqd, api, processor, cron), pre-seeded with a bootstrapped project
- Add `make compose-up-build`, `compose-up`, `compose-down`, `compose-reset`, `compose-ps`
- Fix `es up` migration command silently no-op'ing in the packaged binary (missing `schemaPath` override, now mirrors `pg.ts`)
- Update README: prerequisites, compose usage, smoke-test steps

## Does your change fix a particular issue?

Adds compose-based local setup for testing
